### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/110/872/109/3/1108721093.geojson
+++ b/data/110/872/109/3/1108721093.geojson
@@ -165,6 +165,9 @@
     },
     "wof:country":"OM",
     "wof:created":1476131205,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"6d7731abb598401e754a3fa84884a044",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
         }
     ],
     "wof:id":1108721093,
-    "wof:lastmodified":1566672825,
+    "wof:lastmodified":1582321495,
     "wof:name":"Madha",
     "wof:parent_id":85675709,
     "wof:placetype":"county",

--- a/data/421/169/317/421169317.geojson
+++ b/data/421/169/317/421169317.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459008804,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78b5856b94be7d920bca4afeaa099bf1",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421169317,
-    "wof:lastmodified":1566672859,
+    "wof:lastmodified":1582321496,
     "wof:name":"Al Awabi",
     "wof:parent_id":85675727,
     "wof:placetype":"county",

--- a/data/421/170/285/421170285.geojson
+++ b/data/421/170/285/421170285.geojson
@@ -69,7 +69,6 @@
     "qs:woe_id":55927068,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes",
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -98,6 +97,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459008846,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67786d9e9670765f1f9a87f834b7bc62",
     "wof:hierarchy":[
         {
@@ -108,7 +110,7 @@
         }
     ],
     "wof:id":421170285,
-    "wof:lastmodified":1566672869,
+    "wof:lastmodified":1582321498,
     "wof:name":"Muqshin",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/172/085/421172085.geojson
+++ b/data/421/172/085/421172085.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459008919,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"efba77d8c35bfefd673502a00c433aef",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421172085,
-    "wof:lastmodified":1566672862,
+    "wof:lastmodified":1582321497,
     "wof:name":"Rakhyut",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/172/087/421172087.geojson
+++ b/data/421/172/087/421172087.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459008920,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"be30270c93626f3c31c4102360085754",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421172087,
-    "wof:lastmodified":1566672863,
+    "wof:lastmodified":1582321497,
     "wof:name":"Al Jazir",
     "wof:parent_id":85675685,
     "wof:placetype":"county",

--- a/data/421/175/629/421175629.geojson
+++ b/data/421/175/629/421175629.geojson
@@ -230,6 +230,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009074,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b712e08caefd987708b46584b35d0d3",
     "wof:hierarchy":[
         {
@@ -240,7 +243,7 @@
         }
     ],
     "wof:id":421175629,
-    "wof:lastmodified":1566672864,
+    "wof:lastmodified":1582321497,
     "wof:name":"Sur",
     "wof:parent_id":85675691,
     "wof:placetype":"county",

--- a/data/421/175/631/421175631.geojson
+++ b/data/421/175/631/421175631.geojson
@@ -185,6 +185,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009074,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"31d4eb29d76540a35e4da4b0356294f5",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":421175631,
-    "wof:lastmodified":1566672864,
+    "wof:lastmodified":1582321497,
     "wof:name":"Masirah",
     "wof:parent_id":85675691,
     "wof:placetype":"county",

--- a/data/421/178/455/421178455.geojson
+++ b/data/421/178/455/421178455.geojson
@@ -562,6 +562,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009182,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c6f84e8b2e697e3feb05a61e2561603",
     "wof:hierarchy":[
         {
@@ -573,7 +576,7 @@
         }
     ],
     "wof:id":421178455,
-    "wof:lastmodified":1566672870,
+    "wof:lastmodified":1582321498,
     "wof:name":"Muscat",
     "wof:parent_id":421185635,
     "wof:placetype":"locality",

--- a/data/421/183/959/421183959.geojson
+++ b/data/421/183/959/421183959.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009396,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8cf587fddfc0a74bb9478e2c573d9d4",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421183959,
-    "wof:lastmodified":1566672870,
+    "wof:lastmodified":1582321498,
     "wof:name":"Shinas",
     "wof:parent_id":85675703,
     "wof:placetype":"county",

--- a/data/421/184/219/421184219.geojson
+++ b/data/421/184/219/421184219.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009404,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c2a1f077601919fbdd3f3d74c957720c",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421184219,
-    "wof:lastmodified":1566672868,
+    "wof:lastmodified":1582321498,
     "wof:name":"As Suwayq",
     "wof:parent_id":85675703,
     "wof:placetype":"county",

--- a/data/421/184/221/421184221.geojson
+++ b/data/421/184/221/421184221.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009404,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8ecbd85fb69c12201fc3292dd6a9975",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421184221,
-    "wof:lastmodified":1566672868,
+    "wof:lastmodified":1582321498,
     "wof:name":"Mahawt",
     "wof:parent_id":85675685,
     "wof:placetype":"county",

--- a/data/421/184/225/421184225.geojson
+++ b/data/421/184/225/421184225.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009404,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e75ef8746af2e739fe0d94cd4041cf3",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421184225,
-    "wof:lastmodified":1566672869,
+    "wof:lastmodified":1582321498,
     "wof:name":"Al Buraymi",
     "wof:parent_id":85675717,
     "wof:placetype":"county",

--- a/data/421/184/227/421184227.geojson
+++ b/data/421/184/227/421184227.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009404,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"387388138cf3a1962cfee9b4641d8d9b",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421184227,
-    "wof:lastmodified":1566672868,
+    "wof:lastmodified":1582321497,
     "wof:name":"Thumrayt",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/184/415/421184415.geojson
+++ b/data/421/184/415/421184415.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009410,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4285233ed1bfbe3bee0064e72f809f30",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421184415,
-    "wof:lastmodified":1566672869,
+    "wof:lastmodified":1582321498,
     "wof:name":"Ad Duqm",
     "wof:parent_id":85675685,
     "wof:placetype":"county",

--- a/data/421/184/531/421184531.geojson
+++ b/data/421/184/531/421184531.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009414,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"30efb4497ac63d33801f81f31dd46c48",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421184531,
-    "wof:lastmodified":1566672869,
+    "wof:lastmodified":1582321498,
     "wof:name":"Mahadah",
     "wof:parent_id":85675717,
     "wof:placetype":"county",

--- a/data/421/185/083/421185083.geojson
+++ b/data/421/185/083/421185083.geojson
@@ -197,6 +197,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009432,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a56184e5d0f6d5a436a8a288dd2f81b2",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
         }
     ],
     "wof:id":421185083,
-    "wof:lastmodified":1566672871,
+    "wof:lastmodified":1582321498,
     "wof:name":"Samail",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/421/185/635/421185635.geojson
+++ b/data/421/185/635/421185635.geojson
@@ -466,6 +466,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009449,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"62835f8bb00fcb61ba97e6e0b9fd0dd2",
     "wof:hierarchy":[
         {
@@ -476,7 +479,7 @@
         }
     ],
     "wof:id":421185635,
-    "wof:lastmodified":1566672872,
+    "wof:lastmodified":1582321498,
     "wof:name":"Muscat",
     "wof:parent_id":85675713,
     "wof:placetype":"county",

--- a/data/421/186/553/421186553.geojson
+++ b/data/421/186/553/421186553.geojson
@@ -323,6 +323,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009484,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"df28eea7f7512da5fa19cb47c2f81d54",
     "wof:hierarchy":[
         {
@@ -333,7 +336,7 @@
         }
     ],
     "wof:id":421186553,
-    "wof:lastmodified":1566672863,
+    "wof:lastmodified":1582321497,
     "wof:name":"Qurayyat",
     "wof:parent_id":85675713,
     "wof:placetype":"county",

--- a/data/421/186/667/421186667.geojson
+++ b/data/421/186/667/421186667.geojson
@@ -224,6 +224,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009488,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"981c4d392bcfbe8cb5c87d0caa631fe4",
     "wof:hierarchy":[
         {
@@ -234,7 +237,7 @@
         }
     ],
     "wof:id":421186667,
-    "wof:lastmodified":1566672863,
+    "wof:lastmodified":1582321497,
     "wof:name":"Nizwa",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/421/186/703/421186703.geojson
+++ b/data/421/186/703/421186703.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009489,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"823e6a49f9012b31ea399927f41f3765",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421186703,
-    "wof:lastmodified":1566672863,
+    "wof:lastmodified":1582321497,
     "wof:name":"Mirbat",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/187/061/421187061.geojson
+++ b/data/421/187/061/421187061.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009500,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b0e32f9d93b96bd742958ae7c3e86a06",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421187061,
-    "wof:lastmodified":1566672861,
+    "wof:lastmodified":1582321496,
     "wof:name":"As Seeb",
     "wof:parent_id":85675713,
     "wof:placetype":"county",

--- a/data/421/187/063/421187063.geojson
+++ b/data/421/187/063/421187063.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009500,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d8d081b1b51072fcfc8480f7219469c",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":421187063,
-    "wof:lastmodified":1566672861,
+    "wof:lastmodified":1582321496,
     "wof:name":"Ibri",
     "wof:parent_id":85675699,
     "wof:placetype":"county",

--- a/data/421/189/275/421189275.geojson
+++ b/data/421/189/275/421189275.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009615,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e516e5e8a0077a8312fd3f589ca5b488",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421189275,
-    "wof:lastmodified":1566672861,
+    "wof:lastmodified":1582321496,
     "wof:name":"Taqah",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/189/277/421189277.geojson
+++ b/data/421/189/277/421189277.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009616,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f5406878f0da6c9e0607bf1fe8baf38",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421189277,
-    "wof:lastmodified":1566672862,
+    "wof:lastmodified":1582321496,
     "wof:name":"Dalkut",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/189/279/421189279.geojson
+++ b/data/421/189/279/421189279.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009616,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e3c123edae88548e692a37d836b4cfe",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421189279,
-    "wof:lastmodified":1566672862,
+    "wof:lastmodified":1582321497,
     "wof:name":"Bahla",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/421/189/283/421189283.geojson
+++ b/data/421/189/283/421189283.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009616,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e83263373bfdfa584656f3bb30faa947",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421189283,
-    "wof:lastmodified":1566672862,
+    "wof:lastmodified":1582321496,
     "wof:name":"Hayma",
     "wof:parent_id":85675685,
     "wof:placetype":"county",

--- a/data/421/189/285/421189285.geojson
+++ b/data/421/189/285/421189285.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009616,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b1178d6d0dd1eb0256f240a65dc66f68",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421189285,
-    "wof:lastmodified":1566672862,
+    "wof:lastmodified":1582321497,
     "wof:name":"Manah",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/421/195/037/421195037.geojson
+++ b/data/421/195/037/421195037.geojson
@@ -230,6 +230,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009829,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d6b07c0c52e5200f201b10acfae2ec27",
     "wof:hierarchy":[
         {
@@ -240,7 +243,7 @@
         }
     ],
     "wof:id":421195037,
-    "wof:lastmodified":1566672858,
+    "wof:lastmodified":1582321496,
     "wof:name":"Sohar",
     "wof:parent_id":85675703,
     "wof:placetype":"county",

--- a/data/421/195/841/421195841.geojson
+++ b/data/421/195/841/421195841.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009861,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f9a23ce1aa29cb8017d244725f134eb",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421195841,
-    "wof:lastmodified":1566672858,
+    "wof:lastmodified":1582321496,
     "wof:name":"Al Mudaybi",
     "wof:parent_id":85675721,
     "wof:placetype":"county",

--- a/data/421/195/843/421195843.geojson
+++ b/data/421/195/843/421195843.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459009861,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f67effa203cb101d2475bfdad1e18f4",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421195843,
-    "wof:lastmodified":1566672858,
+    "wof:lastmodified":1582321496,
     "wof:name":"Al Khaburah",
     "wof:parent_id":85675703,
     "wof:placetype":"county",

--- a/data/421/200/933/421200933.geojson
+++ b/data/421/200/933/421200933.geojson
@@ -69,7 +69,6 @@
     "qs:woe_id":55927067,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes",
         "quattroshapes"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -98,6 +97,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459010046,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"44af3389ac74a524b242313b865dce88",
     "wof:hierarchy":[
         {
@@ -108,7 +110,7 @@
         }
     ],
     "wof:id":421200933,
-    "wof:lastmodified":1566672867,
+    "wof:lastmodified":1582321497,
     "wof:name":"Al Amrat",
     "wof:parent_id":85675713,
     "wof:placetype":"county",

--- a/data/421/200/935/421200935.geojson
+++ b/data/421/200/935/421200935.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459010046,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7070c8fce8e2406a3625432f94a1cd2c",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421200935,
-    "wof:lastmodified":1566672867,
+    "wof:lastmodified":1582321497,
     "wof:name":"Bawshar",
     "wof:parent_id":85675713,
     "wof:placetype":"county",

--- a/data/421/200/937/421200937.geojson
+++ b/data/421/200/937/421200937.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459010046,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f72641ea26fd900da4d36ea55ff04f92",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421200937,
-    "wof:lastmodified":1566672867,
+    "wof:lastmodified":1582321497,
     "wof:name":"Bidiyah",
     "wof:parent_id":85675721,
     "wof:placetype":"county",

--- a/data/421/200/939/421200939.geojson
+++ b/data/421/200/939/421200939.geojson
@@ -242,6 +242,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459010046,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"730ae0bc35009a1a01d99169827bc58b",
     "wof:hierarchy":[
         {
@@ -252,7 +255,7 @@
         }
     ],
     "wof:id":421200939,
-    "wof:lastmodified":1566672867,
+    "wof:lastmodified":1582321497,
     "wof:name":"Salalah",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/200/941/421200941.geojson
+++ b/data/421/200/941/421200941.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459010046,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8cb0320859fe2d4ae2bc6db8e61835cf",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421200941,
-    "wof:lastmodified":1566672867,
+    "wof:lastmodified":1582321497,
     "wof:name":"Ar Rustaq",
     "wof:parent_id":85675727,
     "wof:placetype":"county",

--- a/data/421/203/283/421203283.geojson
+++ b/data/421/203/283/421203283.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"OM",
     "wof:created":1459010146,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ecd22db6fdd33428095f3cc9c030fcb8",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421203283,
-    "wof:lastmodified":1566672860,
+    "wof:lastmodified":1582321496,
     "wof:name":"Sadah",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/856/322/07/85632207.geojson
+++ b/data/856/322/07/85632207.geojson
@@ -954,6 +954,12 @@
     },
     "wof:country":"OM",
     "wof:country_alpha3":"OMN",
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"14c0448d79b1e5c987296fc535ab6607",
     "wof:hierarchy":[
         {
@@ -968,7 +974,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566672740,
+    "wof:lastmodified":1582321491,
     "wof:name":"Oman",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/756/81/85675681.geojson
+++ b/data/856/756/81/85675681.geojson
@@ -288,6 +288,9 @@
         "wd:id":"Q792550"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"277ebd5ea41af3ec4bd3f8db34ec788d",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566672741,
+    "wof:lastmodified":1582321492,
     "wof:name":"Ad Dakhliyah",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/756/85/85675685.geojson
+++ b/data/856/756/85/85675685.geojson
@@ -286,6 +286,9 @@
         "wd:id":"Q958518"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2156ae230d60da6301c03c1a72a9d3e",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566672742,
+    "wof:lastmodified":1582321493,
     "wof:name":"Al Wusta",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/756/91/85675691.geojson
+++ b/data/856/756/91/85675691.geojson
@@ -226,6 +226,9 @@
         "wd:id":"Q4501894"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"050b6e1a1f9f328efcef2da97e592794",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566672741,
+    "wof:lastmodified":1582321492,
     "wof:name":"Ash Sharqiyah South",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/756/95/85675695.geojson
+++ b/data/856/756/95/85675695.geojson
@@ -285,6 +285,9 @@
         "wd:id":"Q1207752"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e67b3345adbc4a9f235b7c4978377a2e",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566672741,
+    "wof:lastmodified":1582321492,
     "wof:name":"Dhofar",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/756/99/85675699.geojson
+++ b/data/856/756/99/85675699.geojson
@@ -281,6 +281,9 @@
         "wk:page":"Ad Dhahirah Governorate"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9e0a1a086a8b368e744ff07e156caea2",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566672742,
+    "wof:lastmodified":1582321492,
     "wof:name":"Adh Dhahirah",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/757/03/85675703.geojson
+++ b/data/856/757/03/85675703.geojson
@@ -210,6 +210,9 @@
         "wd:id":"Q4703565"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"832b99158ff81118fb23d9151ff45c40",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566672743,
+    "wof:lastmodified":1582321493,
     "wof:name":"Al Batnah North",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/757/09/85675709.geojson
+++ b/data/856/757/09/85675709.geojson
@@ -299,6 +299,9 @@
         "wd:id":"Q372144"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b356859aecac0ddeafcb17d066295af3",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566672743,
+    "wof:lastmodified":1582321493,
     "wof:name":"Musandam",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/757/13/85675713.geojson
+++ b/data/856/757/13/85675713.geojson
@@ -325,6 +325,9 @@
         "wd:id":"Q544762"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea5ce38d4eee7c85f8a2870e12057251",
     "wof:hierarchy":[
         {
@@ -340,7 +343,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566672744,
+    "wof:lastmodified":1582321493,
     "wof:name":"Muscat",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/757/17/85675717.geojson
+++ b/data/856/757/17/85675717.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Al Buraimi Governorate"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7399648f9e058f298b2fbb53174224e8",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566672743,
+    "wof:lastmodified":1582321493,
     "wof:name":"Al Buraymi",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/757/21/85675721.geojson
+++ b/data/856/757/21/85675721.geojson
@@ -220,6 +220,9 @@
         "wd:id":"Q4501876"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e94b204c80a9a8d4aa0eebdb2233d8b",
     "wof:hierarchy":[
         {
@@ -235,7 +238,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566672743,
+    "wof:lastmodified":1582321493,
     "wof:name":"Ash Sharqiyah North",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/757/27/85675727.geojson
+++ b/data/856/757/27/85675727.geojson
@@ -210,6 +210,9 @@
         "wd:id":"Q4703565"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7bfa8e576650f0444b28a3a721172203",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566672743,
+    "wof:lastmodified":1582321493,
     "wof:name":"Al Batnah South",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/859/037/53/85903753.geojson
+++ b/data/859/037/53/85903753.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":1211426
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"89f87f1957405913ce4833529c767649",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672738,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0627\u0644\u0628\u0633\u062a\u0627\u0646",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/55/85903755.geojson
+++ b/data/859/037/55/85903755.geojson
@@ -83,6 +83,10 @@
         "qs_pg:id":239393
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a0816607ada9a2fc8b6ff7b57db17f4a",
     "wof:hierarchy":[
         {
@@ -98,7 +102,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672738,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0627\u0644\u062d\u0627\u0641\u0629",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/57/85903757.geojson
+++ b/data/859/037/57/85903757.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Bayt al Falaj"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4677fa384294ef6aa95fd9c74521e298",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1534379392,
+    "wof:lastmodified":1582321491,
     "wof:name":"Bayt Al Falaj",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/59/85903759.geojson
+++ b/data/859/037/59/85903759.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":900467
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"567a78d03658b67f7909b893ce87d4ae",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672738,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u063a\u0631\u0628\u0627\u0621",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/61/85903761.geojson
+++ b/data/859/037/61/85903761.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":1131344
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e31b33bf57c52f7ac55a354857c7cbab",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672737,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0631\u064a\u0627\u0645",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/63/85903763.geojson
+++ b/data/859/037/63/85903763.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Sidab"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5af66a1644dfc82937dd075a128ab6bc",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672738,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0633\u062f\u0627\u0628",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/65/85903765.geojson
+++ b/data/859/037/65/85903765.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1131380
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"cb3ed821e83c228b38653dd1c6480493",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672738,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0627\u0644\u0642\u0631\u0645",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/69/85903769.geojson
+++ b/data/859/037/69/85903769.geojson
@@ -106,6 +106,9 @@
         "qs_pg:id":1354441
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2742a4be5b5a3509f9d964ab3701ab37",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672738,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0631\u0648\u064a",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/320/85/85932085.geojson
+++ b/data/859/320/85/85932085.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":991470
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"39605cb0a86bf2b0b80b39218b4459f3",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672739,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0627\u0644\u0642\u0648\u0641",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/320/89/85932089.geojson
+++ b/data/859/320/89/85932089.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":476338
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8d231d5e60908ac7f3262f873bf4ac4f",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672739,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u062c\u0646\u0648\u0628 \u0627\u0644\u062f\u0647\u0627\u0631\u064a\u0632",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/320/93/85932093.geojson
+++ b/data/859/320/93/85932093.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":476341
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2cca696966305ff146f8cddb8cf4856e",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672739,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u062e\u0648\u064a\u0631",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/320/97/85932097.geojson
+++ b/data/859/320/97/85932097.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":1091919
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"801ece0a318fe7411d846268af530254",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672739,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0627\u0644\u0639\u0630\u064a\u0628\u0629 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/03/85932103.geojson
+++ b/data/859/321/03/85932103.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Kalbuh"
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"399ff06380075b5a9256e60d031561d6",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1534379392,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0643\u0644\u0628\u0648\u062d",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/07/85932107.geojson
+++ b/data/859/321/07/85932107.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":476344
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9efdc1bf9eab3ed35ab07010b3a8d23d",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672739,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0627\u0644\u0633\u0627\u0631\u0648\u062c",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/11/85932111.geojson
+++ b/data/859/321/11/85932111.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":476345
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2331912a78b03824cb1afa969cc60979",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672739,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0645\u064a\u0646\u0627\u0621 \u0627\u0644\u0633\u0644\u0637\u0627\u0646 \u0642\u0627\u0628\u0648\u0633",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/13/85932113.geojson
+++ b/data/859/321/13/85932113.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1062211
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b179a6b260466fd932dc60edb39792df",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672740,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0627\u0644\u062d\u0635\u064a\u0644\u062d\u064a",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/19/85932119.geojson
+++ b/data/859/321/19/85932119.geojson
@@ -105,6 +105,9 @@
         "qs_pg:id":268047
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9aec0a21a21c24627b9463da36b1046c",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672739,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0627\u0644\u0648\u0627\u062f\u064a \u0627\u0644\u0643\u0628\u064a\u0631",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/23/85932123.geojson
+++ b/data/859/321/23/85932123.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1080216
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"225ce05255b77c5149ea68ab278f267c",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672739,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0627\u0644\u063a\u0646\u062a\u064a\u0642",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/27/85932127.geojson
+++ b/data/859/321/27/85932127.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":893094
     },
     "wof:country":"OM",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c5b96ab9242360c17582e40e00babbd",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566672739,
+    "wof:lastmodified":1582321491,
     "wof:name":"\u0645\u062f\u064a\u0646\u0629 \u0627\u0644\u0633\u0644\u0637\u0627\u0646 \u0642\u0627\u0628\u0648\u0633",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/441/841/890441841.geojson
+++ b/data/890/441/841/890441841.geojson
@@ -215,6 +215,9 @@
     },
     "wof:country":"OM",
     "wof:created":1469052339,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"25b249cbbb7e2e35488771eb53a1aaf5",
     "wof:hierarchy":[
         {
@@ -225,7 +228,7 @@
         }
     ],
     "wof:id":890441841,
-    "wof:lastmodified":1566672873,
+    "wof:lastmodified":1582321498,
     "wof:name":"Barka",
     "wof:parent_id":85675727,
     "wof:placetype":"county",

--- a/data/890/452/027/890452027.geojson
+++ b/data/890/452/027/890452027.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"OM",
     "wof:created":1469052801,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bebd81d469715fefe8fbb42a4eecbd62",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":890452027,
-    "wof:lastmodified":1566672873,
+    "wof:lastmodified":1582321498,
     "wof:name":"Al Musanaah",
     "wof:parent_id":85675727,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.