### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/112/590/855/1/1125908551.geojson
+++ b/data/112/590/855/1/1125908551.geojson
@@ -20,6 +20,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u062d\u0627\u0631\u0629 \u0627\u0644\u0643\u0645\u0632\u0631\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Harat Al Kamzara"
+    ],
     "qs_pg:aaroncc":"OM",
     "qs_pg:gn_country":"OM",
     "qs_pg:name":"\u062d\u0627\u0631\u0629 \u0627\u0644\u0643\u0645\u0632\u0631\u0627\u0621",
@@ -63,8 +69,8 @@
         }
     ],
     "wof:id":1125908551,
-    "wof:lastmodified":1566672875,
-    "wof:name":"\u062d\u0627\u0631\u0629 \u0627\u0644\u0643\u0645\u0632\u0631\u0627\u0621",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Harat Al Kamzara",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/112/590/855/1/1125908551.geojson
+++ b/data/112/590/855/1/1125908551.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"56.283073,26.2161295,56.283073,26.2161295",
+    "geom:bbox":"56.283073,26.21613,56.283073,26.21613",
     "geom:latitude":26.21613,
     "geom:longitude":56.283073,
     "gn:country":"OM",
@@ -59,7 +59,7 @@
     },
     "wof:country":"OM",
     "wof:created":1497296064,
-    "wof:geomhash":"b94c509214d13077c7b92fdb1143ef3c",
+    "wof:geomhash":"c86ecbfd93d5d925fb3ca44189d482f4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1125908551,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Harat Al Kamzara",
     "wof:parent_id":-1,
     "wof:placetype":"locality",
@@ -80,9 +80,9 @@
 },
   "bbox": [
     56.283073,
-    26.2161295,
+    26.21613,
     56.283073,
-    26.2161295
+    26.21613
 ],
-  "geometry": {"coordinates":[56.283073,26.2161295],"type":"Point"}
+  "geometry": {"coordinates":[56.283073,26.21613],"type":"Point"}
 }

--- a/data/112/606/106/5/1126061065.geojson
+++ b/data/112/606/106/5/1126061065.geojson
@@ -53,10 +53,10 @@
     "woe:name_adm1":"\u0645\u0633\u0642\u0637",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85675713,
         102191569,
         85632207,
-        1108721095
+        1108721095,
+        85675713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1126061065,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Wadi Al Kabeer",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/606/106/5/1126061065.geojson
+++ b/data/112/606/106/5/1126061065.geojson
@@ -20,6 +20,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0648\u0627\u062f\u064a \u0627\u0644\u0643\u0628\u064a\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Al Wadi Al Kabeer"
+    ],
     "qs_pg:aaroncc":"OM",
     "qs_pg:gn_country":"OM",
     "qs_pg:gn_fcode":"PPL",
@@ -72,8 +78,8 @@
         }
     ],
     "wof:id":1126061065,
-    "wof:lastmodified":1534379392,
-    "wof:name":"\u0627\u0644\u0648\u0627\u062f\u064a \u0627\u0644\u0643\u0628\u064a\u0631",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Wadi Al Kabeer",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/112/610/044/9/1126100449.geojson
+++ b/data/112/610/044/9/1126100449.geojson
@@ -20,6 +20,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0631\u0648\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Roy"
+    ],
     "qs_pg:aaroncc":"OM",
     "qs_pg:gn_country":"OM",
     "qs_pg:gn_fcode":"PPL",
@@ -72,8 +78,8 @@
         }
     ],
     "wof:id":1126100449,
-    "wof:lastmodified":1534379392,
-    "wof:name":"\u0631\u0648\u064a",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Roy",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/112/610/044/9/1126100449.geojson
+++ b/data/112/610/044/9/1126100449.geojson
@@ -53,10 +53,10 @@
     "woe:name_adm1":"\u0645\u0633\u0642\u0637",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85675713,
         102191569,
         85632207,
-        1108721095
+        1108721095,
+        85675713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1126100449,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423092,
     "wof:name":"Roy",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/610/724/9/1126107249.geojson
+++ b/data/112/610/724/9/1126107249.geojson
@@ -20,6 +20,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ara_x_preferred":[
+        "\u0633\u062f\u0627\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Sidab"
+    ],
     "qs_pg:aaroncc":"OM",
     "qs_pg:gn_country":"OM",
     "qs_pg:gn_fcode":"PPL",
@@ -72,8 +78,8 @@
         }
     ],
     "wof:id":1126107249,
-    "wof:lastmodified":1534379392,
-    "wof:name":"\u0633\u062f\u0627\u0628",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sidab",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/112/610/724/9/1126107249.geojson
+++ b/data/112/610/724/9/1126107249.geojson
@@ -53,10 +53,10 @@
     "woe:name_adm1":"\u0645\u0633\u0642\u0637",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85675713,
         102191569,
         85632207,
-        421185635
+        421185635,
+        85675713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1126107249,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sidab",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/171/395/421171395.geojson
+++ b/data/421/171/395/421171395.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062d\u064a\u0644 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Hail South"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421171395,
-    "wof:lastmodified":1566672871,
-    "wof:name":"\u062d\u064a\u0644 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Hail South",
     "wof:parent_id":421187061,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/171/395/421171395.geojson
+++ b/data/421/171/395/421171395.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675713,
-        421187061
+        421187061,
+        85675713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421171395,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423089,
     "wof:name":"Hail South",
     "wof:parent_id":421187061,
     "wof:placetype":"locality",

--- a/data/421/171/603/421171603.geojson
+++ b/data/421/171/603/421171603.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421171603,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423088,
     "wof:name":"Dibba Al Baya'a",
     "wof:parent_id":85675709,
     "wof:placetype":"county",

--- a/data/421/171/603/421171603.geojson
+++ b/data/421/171/603/421171603.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062f\u0628\u0627 \u0627\u0644\u0628\u064a\u0639\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "Dibba Al Baya'a"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459008900,
-    "wof:geomhash":"39eb65012998dc5064b2f929afd24bae",
+    "wof:geomhash":"d31214ac8368b1bebeac77cae1493085",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421171603,
-    "wof:lastmodified":1476131661,
-    "wof:name":"\u062f\u0628\u0627 \u0627\u0644\u0628\u064a\u0639\u0647",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Dibba Al Baya'a",
     "wof:parent_id":85675709,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/171/851/421171851.geojson
+++ b/data/421/171/851/421171851.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0648\u0627\u062f\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Al Wadi"
+    ],
     "qs:gn_country":"OM",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":7630473,
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":421171851,
-    "wof:lastmodified":1566672871,
-    "wof:name":"\u0627\u0644\u0648\u0627\u062f\u064a",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Wadi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/171/851/421171851.geojson
+++ b/data/421/171/851/421171851.geojson
@@ -42,10 +42,10 @@
     "qs:woe_id":55926233,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85675695,
         102191569,
         85632207,
-        421200939
+        421200939,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -67,7 +67,7 @@
         }
     ],
     "wof:id":421171851,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Wadi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/171/897/421171897.geojson
+++ b/data/421/171/897/421171897.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421172085
+        421172085,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421171897,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423090,
     "wof:name":"Magra",
     "wof:parent_id":421172085,
     "wof:placetype":"locality",

--- a/data/421/171/897/421171897.geojson
+++ b/data/421/171/897/421171897.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0642\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Magra"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421171897,
-    "wof:lastmodified":1566672871,
-    "wof:name":"\u0645\u0642\u0631\u0629",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Magra",
     "wof:parent_id":421172085,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/172/083/421172083.geojson
+++ b/data/421/172/083/421172083.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0625\u0632\u0643\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Izki"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459008919,
-    "wof:geomhash":"1fa4e87ff9583ba0235a122b1bf68259",
+    "wof:geomhash":"3987edd855debd65d95a6009e32d8626",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421172083,
-    "wof:lastmodified":1476131659,
-    "wof:name":"\u0625\u0632\u0643\u064a",
+    "wof:lastmodified":1601068387,
+    "wof:name":"Izki",
     "wof:parent_id":85675681,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/172/083/421172083.geojson
+++ b/data/421/172/083/421172083.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421172083,
-    "wof:lastmodified":1601068387,
+    "wof:lastmodified":1601423089,
     "wof:name":"Izki",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/421/173/631/421173631.geojson
+++ b/data/421/173/631/421173631.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0633\u0646\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Saniya"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421173631,
-    "wof:lastmodified":1566672861,
-    "wof:name":"\u0627\u0644\u0633\u0646\u064a\u0629",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Saniya",
     "wof:parent_id":1108721073,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/173/631/421173631.geojson
+++ b/data/421/173/631/421173631.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675709,
-        1108721073
+        1108721073,
+        85675709
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421173631,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Saniya",
     "wof:parent_id":1108721073,
     "wof:placetype":"locality",

--- a/data/421/176/961/421176961.geojson
+++ b/data/421/176/961/421176961.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062e\u0648\u0636"
+    ],
+    "name:eng_x_preferred":[
+        "Khoudh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421176961,
-    "wof:lastmodified":1566672871,
-    "wof:name":"\u062e\u0648\u0636",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Khoudh",
     "wof:parent_id":421187061,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/176/961/421176961.geojson
+++ b/data/421/176/961/421176961.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"58.194118,23.6194395,58.194118,23.6194395",
+    "geom:bbox":"58.194118,23.619439,58.194118,23.619439",
     "geom:latitude":23.619439,
     "geom:longitude":58.194118,
     "iso:country":"OM",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675713,
-        421187061
+        421187061,
+        85675713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009128,
-    "wof:geomhash":"3f60e206b8bb9786ae8e2e24a89570b7",
+    "wof:geomhash":"caa0eaeb186912678596fcf1c9c1c4d8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421176961,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423090,
     "wof:name":"Khoudh",
     "wof:parent_id":421187061,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     58.194118,
-    23.6194395,
+    23.619439,
     58.194118,
-    23.6194395
+    23.619439
 ],
-  "geometry": {"coordinates":[58.194118,23.6194395],"type":"Point"}
+  "geometry": {"coordinates":[58.194118,23.619439],"type":"Point"}
 }

--- a/data/421/181/149/421181149.geojson
+++ b/data/421/181/149/421181149.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0627\u062f\u064a \u0628\u0646\u064a \u062e\u0627\u0644\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Wadi Bani Khalid"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421181149,
-    "wof:lastmodified":1566672864,
-    "wof:name":"\u0648\u0627\u062f\u064a \u0628\u0646\u064a \u062e\u0627\u0644\u062f",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Wadi Bani Khalid",
     "wof:parent_id":1108721089,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/181/149/421181149.geojson
+++ b/data/421/181/149/421181149.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675721,
-        1108721089
+        1108721089,
+        85675721
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421181149,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423094,
     "wof:name":"Wadi Bani Khalid",
     "wof:parent_id":1108721089,
     "wof:placetype":"locality",

--- a/data/421/181/151/421181151.geojson
+++ b/data/421/181/151/421181151.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421189275
+        421189275,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421181151,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Kilin",
     "wof:parent_id":421189275,
     "wof:placetype":"locality",

--- a/data/421/181/151/421181151.geojson
+++ b/data/421/181/151/421181151.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0643\u064a\u0644\u064a\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Kilin"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421181151,
-    "wof:lastmodified":1566672863,
-    "wof:name":"\u0643\u064a\u0644\u064a\u0646",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Kilin",
     "wof:parent_id":421189275,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/181/153/421181153.geojson
+++ b/data/421/181/153/421181153.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421172085
+        421172085,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421181153,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Hakam",
     "wof:parent_id":421172085,
     "wof:placetype":"locality",

--- a/data/421/181/153/421181153.geojson
+++ b/data/421/181/153/421181153.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062d\u0627\u0643\u0627\u0645"
+    ],
+    "name:eng_x_preferred":[
+        "Hakam"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421181153,
-    "wof:lastmodified":1566672863,
-    "wof:name":"\u062d\u0627\u0643\u0627\u0645",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Hakam",
     "wof:parent_id":421172085,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/183/059/421183059.geojson
+++ b/data/421/183/059/421183059.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675681,
-        421189285
+        421189285,
+        85675681
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421183059,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Souq",
     "wof:parent_id":421189285,
     "wof:placetype":"locality",

--- a/data/421/183/059/421183059.geojson
+++ b/data/421/183/059/421183059.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0633\u0648\u0642"
+    ],
+    "name:eng_x_preferred":[
+        "Al Souq"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421183059,
-    "wof:lastmodified":1566672870,
-    "wof:name":"\u0627\u0644\u0633\u0648\u0642",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Souq",
     "wof:parent_id":421189285,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/183/061/421183061.geojson
+++ b/data/421/183/061/421183061.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675681,
-        421189279
+        421189279,
+        85675681
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421183061,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Khurm",
     "wof:parent_id":421189279,
     "wof:placetype":"locality",

--- a/data/421/183/061/421183061.geojson
+++ b/data/421/183/061/421183061.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062e\u0631\u0645"
+    ],
+    "name:eng_x_preferred":[
+        "Al Khurm"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421183061,
-    "wof:lastmodified":1566672870,
-    "wof:name":"\u0627\u0644\u062e\u0631\u0645",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Khurm",
     "wof:parent_id":421189279,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/183/325/421183325.geojson
+++ b/data/421/183/325/421183325.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062d\u0631\u064a\u0645\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Harima"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421183325,
-    "wof:lastmodified":1566672870,
-    "wof:name":"\u062d\u0631\u064a\u0645\u0627",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Harima",
     "wof:parent_id":421186553,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/183/325/421183325.geojson
+++ b/data/421/183/325/421183325.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675713,
-        421186553
+        421186553,
+        85675713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421183325,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423089,
     "wof:name":"Harima",
     "wof:parent_id":421186553,
     "wof:placetype":"locality",

--- a/data/421/183/337/421183337.geojson
+++ b/data/421/183/337/421183337.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u064a\u0646\u0627\u0621 \u0635\u0644\u0627\u0644\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Salalah Port"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421183337,
-    "wof:lastmodified":1566672870,
-    "wof:name":"\u0645\u064a\u0646\u0627\u0621 \u0635\u0644\u0627\u0644\u0629",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Salalah Port",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/183/337/421183337.geojson
+++ b/data/421/183/337/421183337.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"53.9975875,16.943103,53.9975875,16.943103",
+    "geom:bbox":"53.997588,16.943103,53.997588,16.943103",
     "geom:latitude":16.943103,
     "geom:longitude":53.997588,
     "iso:country":"OM",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421200939
+        421200939,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009366,
-    "wof:geomhash":"18caa62193fea5509bead63dc23439ae",
+    "wof:geomhash":"e631b457b838ad2e04c50e4b926acd73",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421183337,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423092,
     "wof:name":"Salalah Port",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    53.9975875,
+    53.997588,
     16.943103,
-    53.9975875,
+    53.997588,
     16.943103
 ],
-  "geometry": {"coordinates":[53.9975875,16.943103],"type":"Point"}
+  "geometry": {"coordinates":[53.997588,16.943103],"type":"Point"}
 }

--- a/data/421/183/339/421183339.geojson
+++ b/data/421/183/339/421183339.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421186703
+        421186703,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421183339,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Jabal Samhan",
     "wof:parent_id":421186703,
     "wof:placetype":"locality",

--- a/data/421/183/339/421183339.geojson
+++ b/data/421/183/339/421183339.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062c\u0628\u0644 \u0633\u0645\u062d\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Jabal Samhan"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421183339,
-    "wof:lastmodified":1566672870,
-    "wof:name":"\u062c\u0628\u0644 \u0633\u0645\u062d\u0627\u0646",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Jabal Samhan",
     "wof:parent_id":421186703,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/183/957/421183957.geojson
+++ b/data/421/183/957/421183957.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"59.076037,23.0339035,59.076037,23.0339035",
+    "geom:bbox":"59.076037,23.033904,59.076037,23.033904",
     "geom:latitude":23.033904,
     "geom:longitude":59.076037,
     "iso:country":"OM",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675713,
-        421186553
+        421186553,
+        85675713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009396,
-    "wof:geomhash":"8896a5423edbad5343f82f90997c88dc",
+    "wof:geomhash":"5a62c0024c61d05ee47285c36e2c7a04",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421183957,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Kitar",
     "wof:parent_id":421186553,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     59.076037,
-    23.0339035,
+    23.033904,
     59.076037,
-    23.0339035
+    23.033904
 ],
-  "geometry": {"coordinates":[59.076037,23.0339035],"type":"Point"}
+  "geometry": {"coordinates":[59.076037,23.033904],"type":"Point"}
 }

--- a/data/421/183/957/421183957.geojson
+++ b/data/421/183/957/421183957.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0642\u0637\u0627\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Kitar"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421183957,
-    "wof:lastmodified":1566672870,
-    "wof:name":"\u0642\u0637\u0627\u0631",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Kitar",
     "wof:parent_id":421186553,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/184/215/421184215.geojson
+++ b/data/421/184/215/421184215.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0635\u0641\u0648\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Masfut"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009404,
-    "wof:geomhash":"f09385038537007752ac8644e7603e20",
+    "wof:geomhash":"3f5c3cefef789c3896a11ae8c371aaa5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421184215,
-    "wof:lastmodified":1476131659,
-    "wof:name":"\u0645\u0635\u0641\u0648\u062a",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Masfut",
     "wof:parent_id":85675717,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/184/215/421184215.geojson
+++ b/data/421/184/215/421184215.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421184215,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423090,
     "wof:name":"Masfut",
     "wof:parent_id":85675717,
     "wof:placetype":"county",

--- a/data/421/184/677/421184677.geojson
+++ b/data/421/184/677/421184677.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0633\u0644\u064a\u0641"
+    ],
+    "name:eng_x_preferred":[
+        "As Sulaif"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421184677,
-    "wof:lastmodified":1566672869,
-    "wof:name":"\u0627\u0644\u0633\u0644\u064a\u0641",
+    "wof:lastmodified":1601068390,
+    "wof:name":"As Sulaif",
     "wof:parent_id":421187063,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/184/677/421184677.geojson
+++ b/data/421/184/677/421184677.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675699,
-        421187063
+        421187063,
+        85675699
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421184677,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423087,
     "wof:name":"As Sulaif",
     "wof:parent_id":421187063,
     "wof:placetype":"locality",

--- a/data/421/184/681/421184681.geojson
+++ b/data/421/184/681/421184681.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062a\u0646\u0648\u0641"
+    ],
+    "name:eng_x_preferred":[
+        "Tanuf"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421184681,
-    "wof:lastmodified":1566672867,
-    "wof:name":"\u062a\u0646\u0648\u0641",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Tanuf",
     "wof:parent_id":421186667,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/184/681/421184681.geojson
+++ b/data/421/184/681/421184681.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675681,
-        421186667
+        421186667,
+        85675681
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421184681,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tanuf",
     "wof:parent_id":421186667,
     "wof:placetype":"locality",

--- a/data/421/185/435/421185435.geojson
+++ b/data/421/185/435/421185435.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421172085
+        421172085,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185435,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Rakhyut",
     "wof:parent_id":421172085,
     "wof:placetype":"locality",

--- a/data/421/185/435/421185435.geojson
+++ b/data/421/185/435/421185435.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u062e\u064a\u0648\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Rakhyut"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185435,
-    "wof:lastmodified":1566672872,
-    "wof:name":"\u0631\u062e\u064a\u0648\u062a",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Rakhyut",
     "wof:parent_id":421172085,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/185/437/421185437.geojson
+++ b/data/421/185/437/421185437.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0635\u062d\u0627\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Sahar"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185437,
-    "wof:lastmodified":1566672872,
-    "wof:name":"\u0635\u062d\u0627\u0631",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sahar",
     "wof:parent_id":421195037,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/185/437/421185437.geojson
+++ b/data/421/185/437/421185437.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"56.733741,24.3635555,56.733741,24.3635555",
+    "geom:bbox":"56.733741,24.363556,56.733741,24.363556",
     "geom:latitude":24.363556,
     "geom:longitude":56.733741,
     "iso:country":"OM",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675703,
-        421195037
+        421195037,
+        85675703
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009443,
-    "wof:geomhash":"57699c0fbc858922801d2911469b05f8",
+    "wof:geomhash":"1b20b85723327281cadbf1bb91c05125",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185437,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sahar",
     "wof:parent_id":421195037,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     56.733741,
-    24.3635555,
+    24.363556,
     56.733741,
-    24.3635555
+    24.363556
 ],
-  "geometry": {"coordinates":[56.733741,24.3635555],"type":"Point"}
+  "geometry": {"coordinates":[56.733741,24.363556],"type":"Point"}
 }

--- a/data/421/185/439/421185439.geojson
+++ b/data/421/185/439/421185439.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062d\u0645\u0631\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Hamriya"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185439,
-    "wof:lastmodified":1566672871,
-    "wof:name":"\u062d\u0645\u0631\u064a\u0629",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Hamriya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/185/439/421185439.geojson
+++ b/data/421/185/439/421185439.geojson
@@ -42,10 +42,10 @@
     "qs:woe_id":2268286,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85675713,
         102191569,
         85632207,
-        1108721095
+        1108721095,
+        85675713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185439,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423089,
     "wof:name":"Hamriya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/185/707/421185707.geojson
+++ b/data/421/185/707/421185707.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062f\u0631\u0628\u064a\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Darbeeb"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185707,
-    "wof:lastmodified":1566672871,
-    "wof:name":"\u062f\u0631\u0628\u064a\u0628",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Darbeeb",
     "wof:parent_id":421186703,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/185/707/421185707.geojson
+++ b/data/421/185/707/421185707.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421186703
+        421186703,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185707,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423088,
     "wof:name":"Darbeeb",
     "wof:parent_id":421186703,
     "wof:placetype":"locality",

--- a/data/421/185/709/421185709.geojson
+++ b/data/421/185/709/421185709.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675713,
-        1108721095
+        1108721095,
+        85675713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185709,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423091,
     "wof:name":"Mutrah",
     "wof:parent_id":1108721095,
     "wof:placetype":"locality",

--- a/data/421/185/709/421185709.geojson
+++ b/data/421/185/709/421185709.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0637\u0631\u062d"
+    ],
+    "name:eng_x_preferred":[
+        "Mutrah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185709,
-    "wof:lastmodified":1566672871,
-    "wof:name":"\u0645\u0637\u0631\u062d",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Mutrah",
     "wof:parent_id":1108721095,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/185/711/421185711.geojson
+++ b/data/421/185/711/421185711.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0646\u062e\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Nakhel"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185711,
-    "wof:lastmodified":1566672872,
-    "wof:name":"\u0646\u062e\u0644",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Nakhel",
     "wof:parent_id":1108721091,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/185/711/421185711.geojson
+++ b/data/421/185/711/421185711.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675727,
-        1108721091
+        1108721091,
+        85675727
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185711,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423091,
     "wof:name":"Nakhel",
     "wof:parent_id":1108721091,
     "wof:placetype":"locality",

--- a/data/421/185/713/421185713.geojson
+++ b/data/421/185/713/421185713.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u063a\u0633\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mughsayl"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185713,
-    "wof:lastmodified":1566672872,
-    "wof:name":"\u0627\u0644\u0645\u063a\u0633\u064a\u0644",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Mughsayl",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/185/713/421185713.geojson
+++ b/data/421/185/713/421185713.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421200939
+        421200939,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185713,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mughsayl",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",

--- a/data/421/185/715/421185715.geojson
+++ b/data/421/185/715/421185715.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0646\u0632\u0648\u0649"
+    ],
+    "name:eng_x_preferred":[
+        "Nizwa"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185715,
-    "wof:lastmodified":1566672872,
-    "wof:name":"\u0646\u0632\u0648\u0649",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Nizwa",
     "wof:parent_id":421186667,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/185/715/421185715.geojson
+++ b/data/421/185/715/421185715.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"57.530593,22.9339155,57.530593,22.9339155",
+    "geom:bbox":"57.530593,22.933916,57.530593,22.933916",
     "geom:latitude":22.933916,
     "geom:longitude":57.530593,
     "iso:country":"OM",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675681,
-        421186667
+        421186667,
+        85675681
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009452,
-    "wof:geomhash":"5ac4ac8cf318041fec96c72ed7066f15",
+    "wof:geomhash":"5d60b7838582fb109dc5d942c264522a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185715,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423091,
     "wof:name":"Nizwa",
     "wof:parent_id":421186667,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     57.530593,
-    22.9339155,
+    22.933916,
     57.530593,
-    22.9339155
+    22.933916
 ],
-  "geometry": {"coordinates":[57.530593,22.9339155],"type":"Point"}
+  "geometry": {"coordinates":[57.530593,22.933916],"type":"Point"}
 }

--- a/data/421/186/547/421186547.geojson
+++ b/data/421/186/547/421186547.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062e\u0648\u064a\u0631\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Khuwayriyyah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186547,
-    "wof:lastmodified":1566672863,
-    "wof:name":"\u0627\u0644\u062e\u0648\u064a\u0631\u064a\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Khuwayriyyah",
     "wof:parent_id":421195037,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/186/547/421186547.geojson
+++ b/data/421/186/547/421186547.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675703,
-        421195037
+        421195037,
+        85675703
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421186547,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Khuwayriyyah",
     "wof:parent_id":421195037,
     "wof:placetype":"locality",

--- a/data/421/186/669/421186669.geojson
+++ b/data/421/186/669/421186669.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421186669,
-    "wof:lastmodified":1601068387,
+    "wof:lastmodified":1601423089,
     "wof:name":"Ibra",
     "wof:parent_id":85675721,
     "wof:placetype":"county",

--- a/data/421/186/669/421186669.geojson
+++ b/data/421/186/669/421186669.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0625\u0628\u0631\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Ibra"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009488,
-    "wof:geomhash":"e20d8cb1b99271e499c900a714ff43eb",
+    "wof:geomhash":"7ad26eedf0379531cc11bbc153106463",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421186669,
-    "wof:lastmodified":1476131660,
-    "wof:name":"\u0625\u0628\u0631\u0627\u0621",
+    "wof:lastmodified":1601068387,
+    "wof:name":"Ibra",
     "wof:parent_id":85675721,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/187/091/421187091.geojson
+++ b/data/421/187/091/421187091.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421200939
+        421200939,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421187091,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423090,
     "wof:name":"Jujub",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",

--- a/data/421/187/091/421187091.geojson
+++ b/data/421/187/091/421187091.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062c\u0648\u062c\u0648\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Jujub"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421187091,
-    "wof:lastmodified":1566672860,
-    "wof:name":"\u062c\u0648\u062c\u0648\u0628",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Jujub",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/188/279/421188279.geojson
+++ b/data/421/188/279/421188279.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675691,
-        421175629
+        421175629,
+        85675691
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421188279,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423091,
     "wof:name":"Nessma",
     "wof:parent_id":421175629,
     "wof:placetype":"locality",

--- a/data/421/188/279/421188279.geojson
+++ b/data/421/188/279/421188279.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0646\u0633\u0645\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Nessma"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421188279,
-    "wof:lastmodified":1566672862,
-    "wof:name":"\u0646\u0633\u0645\u0629",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Nessma",
     "wof:parent_id":421175629,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/188/281/421188281.geojson
+++ b/data/421/188/281/421188281.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421200939
+        421200939,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421188281,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Nabi Ayoub",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",

--- a/data/421/188/281/421188281.geojson
+++ b/data/421/188/281/421188281.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0646\u0628\u064a \u0627\u064a\u0648\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Al Nabi Ayoub"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421188281,
-    "wof:lastmodified":1566672862,
-    "wof:name":"\u0627\u0644\u0646\u0628\u064a \u0627\u064a\u0648\u0628",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Nabi Ayoub",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/127/421191127.geojson
+++ b/data/421/191/127/421191127.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421189277
+        421189277,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191127,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423088,
     "wof:name":"Dhalkut",
     "wof:parent_id":421189277,
     "wof:placetype":"locality",

--- a/data/421/191/127/421191127.geojson
+++ b/data/421/191/127/421191127.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0636\u0644\u0643\u0648\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Dhalkut"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191127,
-    "wof:lastmodified":1566672865,
-    "wof:name":"\u0636\u0644\u0643\u0648\u062a",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Dhalkut",
     "wof:parent_id":421189277,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/129/421191129.geojson
+++ b/data/421/191/129/421191129.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675709,
-        1108721073
+        1108721073,
+        85675709
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191129,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Harf",
     "wof:parent_id":1108721073,
     "wof:placetype":"locality",

--- a/data/421/191/129/421191129.geojson
+++ b/data/421/191/129/421191129.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062d\u0631\u0641"
+    ],
+    "name:eng_x_preferred":[
+        "Al Harf"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191129,
-    "wof:lastmodified":1566672865,
-    "wof:name":"\u0627\u0644\u062d\u0631\u0641",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Harf",
     "wof:parent_id":1108721073,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/131/421191131.geojson
+++ b/data/421/191/131/421191131.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675709,
-        1108721073
+        1108721073,
+        85675709
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191131,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423090,
     "wof:name":"Khasab",
     "wof:parent_id":1108721073,
     "wof:placetype":"locality",

--- a/data/421/191/131/421191131.geojson
+++ b/data/421/191/131/421191131.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062e\u0635\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Khasab"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191131,
-    "wof:lastmodified":1566672865,
-    "wof:name":"\u062e\u0635\u0628",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Khasab",
     "wof:parent_id":1108721073,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/133/421191133.geojson
+++ b/data/421/191/133/421191133.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675709,
-        1108721073
+        1108721073,
+        85675709
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191133,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423091,
     "wof:name":"Qaida",
     "wof:parent_id":1108721073,
     "wof:placetype":"locality",

--- a/data/421/191/133/421191133.geojson
+++ b/data/421/191/133/421191133.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0642\u064a\u062f\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Qaida"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191133,
-    "wof:lastmodified":1566672865,
-    "wof:name":"\u0642\u064a\u062f\u0627\u0621",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Qaida",
     "wof:parent_id":1108721073,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/137/421191137.geojson
+++ b/data/421/191/137/421191137.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u064a\u0633\u0648\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Raysut"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191137,
-    "wof:lastmodified":1566672866,
-    "wof:name":"\u0631\u064a\u0633\u0648\u062a",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Raysut",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/137/421191137.geojson
+++ b/data/421/191/137/421191137.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421200939
+        421200939,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191137,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Raysut",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",

--- a/data/421/191/139/421191139.geojson
+++ b/data/421/191/139/421191139.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u0633\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Al Rusayl"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191139,
-    "wof:lastmodified":1566672866,
-    "wof:name":"\u0627\u0644\u0631\u0633\u064a\u0644",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Rusayl",
     "wof:parent_id":421187061,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/139/421191139.geojson
+++ b/data/421/191/139/421191139.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"58.2017465,23.5886435,58.2017465,23.5886435",
+    "geom:bbox":"58.201746,23.588643,58.201746,23.588643",
     "geom:latitude":23.588643,
     "geom:longitude":58.201746,
     "iso:country":"OM",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675713,
-        421187061
+        421187061,
+        85675713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009681,
-    "wof:geomhash":"cfbc328f0f54115ad6596c4cdd602279",
+    "wof:geomhash":"20b2d6a12b06bee572c10dd12a79922b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191139,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Rusayl",
     "wof:parent_id":421187061,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    58.2017465,
-    23.5886435,
-    58.2017465,
-    23.5886435
+    58.201746,
+    23.588643,
+    58.201746,
+    23.588643
 ],
-  "geometry": {"coordinates":[58.2017465,23.5886435],"type":"Point"}
+  "geometry": {"coordinates":[58.201746,23.588643],"type":"Point"}
 }

--- a/data/421/191/141/421191141.geojson
+++ b/data/421/191/141/421191141.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0634\u0647\u064a\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Ashhayt"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191141,
-    "wof:lastmodified":1566672866,
-    "wof:name":"\u0627\u0634\u0647\u064a\u062a",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Ashhayt",
     "wof:parent_id":421189275,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/141/421191141.geojson
+++ b/data/421/191/141/421191141.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421189275
+        421189275,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191141,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Ashhayt",
     "wof:parent_id":421189275,
     "wof:placetype":"locality",

--- a/data/421/191/143/421191143.geojson
+++ b/data/421/191/143/421191143.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0633\u0648\u064a\u0642"
+    ],
+    "name:eng_x_preferred":[
+        "Al Suwayq"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191143,
-    "wof:lastmodified":1566672865,
-    "wof:name":"\u0627\u0644\u0633\u0648\u064a\u0642",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Suwayq",
     "wof:parent_id":421184219,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/143/421191143.geojson
+++ b/data/421/191/143/421191143.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675703,
-        421184219
+        421184219,
+        85675703
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191143,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Suwayq",
     "wof:parent_id":421184219,
     "wof:placetype":"locality",

--- a/data/421/191/149/421191149.geojson
+++ b/data/421/191/149/421191149.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675721,
-        421200937
+        421200937,
+        85675721
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191149,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mountreb",
     "wof:parent_id":421200937,
     "wof:placetype":"locality",

--- a/data/421/191/149/421191149.geojson
+++ b/data/421/191/149/421191149.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0646\u062a\u0631\u064a\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mountreb"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191149,
-    "wof:lastmodified":1566672866,
-    "wof:name":"\u0627\u0644\u0645\u0646\u062a\u0631\u064a\u0628",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Mountreb",
     "wof:parent_id":421200937,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/151/421191151.geojson
+++ b/data/421/191/151/421191151.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0628\u0631\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Ibra"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191151,
-    "wof:lastmodified":1566672865,
-    "wof:name":"\u0627\u0628\u0631\u0627\u0621",
+    "wof:lastmodified":1601068387,
+    "wof:name":"Ibra",
     "wof:parent_id":1108721051,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/151/421191151.geojson
+++ b/data/421/191/151/421191151.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675721,
-        1108721051
+        1108721051,
+        85675721
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191151,
-    "wof:lastmodified":1601068387,
+    "wof:lastmodified":1601423089,
     "wof:name":"Ibra",
     "wof:parent_id":1108721051,
     "wof:placetype":"locality",

--- a/data/421/191/155/421191155.geojson
+++ b/data/421/191/155/421191155.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"56.5148155,23.23614,56.5148155,23.23614",
+    "geom:bbox":"56.514815,23.23614,56.514815,23.23614",
     "geom:latitude":23.23614,
     "geom:longitude":56.514815,
     "iso:country":"OM",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675699,
-        421187063
+        421187063,
+        85675699
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009682,
-    "wof:geomhash":"93e31947356382254dd1ae320919252a",
+    "wof:geomhash":"19a6731105204559ce996c959921d223",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191155,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423089,
     "wof:name":"Ibri",
     "wof:parent_id":421187063,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    56.5148155,
+    56.514815,
     23.23614,
-    56.5148155,
+    56.514815,
     23.23614
 ],
-  "geometry": {"coordinates":[56.5148155,23.23614],"type":"Point"}
+  "geometry": {"coordinates":[56.514815,23.23614],"type":"Point"}
 }

--- a/data/421/191/155/421191155.geojson
+++ b/data/421/191/155/421191155.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0628\u0631\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Ibri"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191155,
-    "wof:lastmodified":1566672866,
-    "wof:name":"\u0639\u0628\u0631\u064a",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Ibri",
     "wof:parent_id":421187063,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/157/421191157.geojson
+++ b/data/421/191/157/421191157.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0641\u0646\u062c\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Fanja"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191157,
-    "wof:lastmodified":1566672864,
-    "wof:name":"\u0641\u0646\u062c\u0627\u0621",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Fanja",
     "wof:parent_id":1108721067,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/157/421191157.geojson
+++ b/data/421/191/157/421191157.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"58.1106585,23.4610215,58.1106585,23.4610215",
+    "geom:bbox":"58.110658,23.461022,58.110658,23.461022",
     "geom:latitude":23.461022,
     "geom:longitude":58.110658,
     "iso:country":"OM",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675681,
-        1108721067
+        1108721067,
+        85675681
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009682,
-    "wof:geomhash":"15a993ca7e0c0b1a1ccee4d217b04507",
+    "wof:geomhash":"8ea92179c0a83040e07b5d818013f15f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191157,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423089,
     "wof:name":"Fanja",
     "wof:parent_id":1108721067,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    58.1106585,
-    23.4610215,
-    58.1106585,
-    23.4610215
+    58.110658,
+    23.461022,
+    58.110658,
+    23.461022
 ],
-  "geometry": {"coordinates":[58.1106585,23.4610215],"type":"Point"}
+  "geometry": {"coordinates":[58.110658,23.461022],"type":"Point"}
 }

--- a/data/421/191/161/421191161.geojson
+++ b/data/421/191/161/421191161.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0635\u0648\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Sur"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191161,
-    "wof:lastmodified":1566672864,
-    "wof:name":"\u0635\u0648\u0631",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Sur",
     "wof:parent_id":421175629,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/161/421191161.geojson
+++ b/data/421/191/161/421191161.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"59.5086045,22.577079,59.5086045,22.577079",
+    "geom:bbox":"59.508604,22.577079,59.508604,22.577079",
     "geom:latitude":22.577079,
     "geom:longitude":59.508604,
     "iso:country":"OM",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675691,
-        421175629
+        421175629,
+        85675691
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009682,
-    "wof:geomhash":"2d5f36589a5801621bf8178ec31e9e58",
+    "wof:geomhash":"c75daf92668ed4890d01846e02a8c62e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191161,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sur",
     "wof:parent_id":421175629,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    59.5086045,
+    59.508604,
     22.577079,
-    59.5086045,
+    59.508604,
     22.577079
 ],
-  "geometry": {"coordinates":[59.5086045,22.577079],"type":"Point"}
+  "geometry": {"coordinates":[59.508604,22.577079],"type":"Point"}
 }

--- a/data/421/191/163/421191163.geojson
+++ b/data/421/191/163/421191163.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0635\u0644\u0627\u0644\u0629 \u0627\u0644\u0634\u0631\u0642\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Salalah East"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191163,
-    "wof:lastmodified":1566672865,
-    "wof:name":"\u0635\u0644\u0627\u0644\u0629 \u0627\u0644\u0634\u0631\u0642\u064a\u0629",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Salalah East",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/163/421191163.geojson
+++ b/data/421/191/163/421191163.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"54.1050905,17.01696,54.1050905,17.01696",
+    "geom:bbox":"54.105091,17.01696,54.105091,17.01696",
     "geom:latitude":17.01696,
     "geom:longitude":54.105091,
     "iso:country":"OM",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421200939
+        421200939,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009682,
-    "wof:geomhash":"f477e422cf7dc926c5dcba6b522ee81a",
+    "wof:geomhash":"71fa168580c430141ac74d2b72f72293",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191163,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Salalah East",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    54.1050905,
+    54.105091,
     17.01696,
-    54.1050905,
+    54.105091,
     17.01696
 ],
-  "geometry": {"coordinates":[54.1050905,17.01696],"type":"Point"}
+  "geometry": {"coordinates":[54.105091,17.01696],"type":"Point"}
 }

--- a/data/421/191/165/421191165.geojson
+++ b/data/421/191/165/421191165.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0634\u064a\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Sheir"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191165,
-    "wof:lastmodified":1566672865,
-    "wof:name":"\u0634\u064a\u0631",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sheir",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/191/165/421191165.geojson
+++ b/data/421/191/165/421191165.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421200939
+        421200939,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191165,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sheir",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",

--- a/data/421/191/167/421191167.geojson
+++ b/data/421/191/167/421191167.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675691,
-        421175629
+        421175629,
+        85675691
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421191167,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423093,
     "wof:name":"Tiwi",
     "wof:parent_id":421175629,
     "wof:placetype":"locality",

--- a/data/421/191/167/421191167.geojson
+++ b/data/421/191/167/421191167.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0637\u064a\u0648\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Tiwi"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421191167,
-    "wof:lastmodified":1566672865,
-    "wof:name":"\u0637\u064a\u0648\u064a",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Tiwi",
     "wof:parent_id":421175629,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/193/741/421193741.geojson
+++ b/data/421/193/741/421193741.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u0627\u0633 \u0627\u0644\u062c\u0646\u0632"
+    ],
+    "name:eng_x_preferred":[
+        "Ras Al Jinz"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421193741,
-    "wof:lastmodified":1566672859,
-    "wof:name":"\u0631\u0627\u0633 \u0627\u0644\u062c\u0646\u0632",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Ras Al Jinz",
     "wof:parent_id":421175629,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/193/741/421193741.geojson
+++ b/data/421/193/741/421193741.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675691,
-        421175629
+        421175629,
+        85675691
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421193741,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Ras Al Jinz",
     "wof:parent_id":421175629,
     "wof:placetype":"locality",

--- a/data/421/194/147/421194147.geojson
+++ b/data/421/194/147/421194147.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u063a\u062f\u064a\u0647"
+    ],
+    "name:eng_x_preferred":[
+        "Ghadiyah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421194147,
-    "wof:lastmodified":1566672859,
-    "wof:name":"\u063a\u062f\u064a\u0647",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Ghadiyah",
     "wof:parent_id":421189275,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/194/147/421194147.geojson
+++ b/data/421/194/147/421194147.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421189275
+        421189275,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421194147,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423089,
     "wof:name":"Ghadiyah",
     "wof:parent_id":421189275,
     "wof:placetype":"locality",

--- a/data/421/194/149/421194149.geojson
+++ b/data/421/194/149/421194149.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062e\u0635\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Al Khasab"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -42,7 +48,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009795,
-    "wof:geomhash":"a74fcaeee546db522202836db981a974",
+    "wof:geomhash":"762045d59e313cf933f418f7640a913b",
     "wof:hierarchy":[
         {
             "country_id":85632207,
@@ -50,8 +56,8 @@
         }
     ],
     "wof:id":421194149,
-    "wof:lastmodified":1476131661,
-    "wof:name":"\u0627\u0644\u062e\u0635\u0628",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Khasab",
     "wof:parent_id":-1,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/194/149/421194149.geojson
+++ b/data/421/194/149/421194149.geojson
@@ -56,7 +56,7 @@
         }
     ],
     "wof:id":421194149,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Khasab",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/421/196/559/421196559.geojson
+++ b/data/421/196/559/421196559.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0644\u062f \u0635\u064a\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Bilad Sayt"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421196559,
-    "wof:lastmodified":1566672864,
-    "wof:name":"\u0628\u0644\u062f \u0635\u064a\u062a",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bilad Sayt",
     "wof:parent_id":421169317,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/196/559/421196559.geojson
+++ b/data/421/196/559/421196559.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675727,
-        421169317
+        421169317,
+        85675727
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421196559,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Bilad Sayt",
     "wof:parent_id":421169317,
     "wof:placetype":"locality",

--- a/data/421/196/561/421196561.geojson
+++ b/data/421/196/561/421196561.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421196561,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423091,
     "wof:name":"Muqshin",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/196/561/421196561.geojson
+++ b/data/421/196/561/421196561.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0642\u0634\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Muqshin"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"OM",
     "wof:created":1459009885,
-    "wof:geomhash":"95dddfe18867a2027ded2a829df15cd6",
+    "wof:geomhash":"123dc6e7ef3085eee8962c932293bb45",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421196561,
-    "wof:lastmodified":1476131660,
-    "wof:name":"\u0645\u0642\u0634\u0646",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Muqshin",
     "wof:parent_id":85675695,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/199/393/421199393.geojson
+++ b/data/421/199/393/421199393.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0634\u0646\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Shinna"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421199393,
-    "wof:lastmodified":1566672866,
-    "wof:name":"\u0634\u0646\u0629",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Shinna",
     "wof:parent_id":421184221,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/199/393/421199393.geojson
+++ b/data/421/199/393/421199393.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675685,
-        421184221
+        421184221,
+        85675685
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421199393,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Shinna",
     "wof:parent_id":421184221,
     "wof:placetype":"locality",

--- a/data/421/201/901/421201901.geojson
+++ b/data/421/201/901/421201901.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675713,
-        421187061
+        421187061,
+        85675713
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421201901,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Murtafia'a",
     "wof:parent_id":421187061,
     "wof:placetype":"locality",

--- a/data/421/201/901/421201901.geojson
+++ b/data/421/201/901/421201901.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0631\u062a\u0641\u0639\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Murtafia'a"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421201901,
-    "wof:lastmodified":1566672867,
-    "wof:name":"\u0627\u0644\u0645\u0631\u062a\u0641\u0639\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Murtafia'a",
     "wof:parent_id":421187061,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/202/801/421202801.geojson
+++ b/data/421/202/801/421202801.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u064a\u0646 \u0631\u0632\u0627\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Ain Razat"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421202801,
-    "wof:lastmodified":1566672860,
-    "wof:name":"\u0639\u064a\u0646 \u0631\u0632\u0627\u062a",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Ain Razat",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/202/801/421202801.geojson
+++ b/data/421/202/801/421202801.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421200939
+        421200939,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421202801,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423083,
     "wof:name":"Ain Razat",
     "wof:parent_id":421200939,
     "wof:placetype":"locality",

--- a/data/421/203/503/421203503.geojson
+++ b/data/421/203/503/421203503.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        1108721081
+        1108721081,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421203503,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423087,
     "wof:name":"Ash Shuwaymiya",
     "wof:parent_id":1108721081,
     "wof:placetype":"locality",

--- a/data/421/203/503/421203503.geojson
+++ b/data/421/203/503/421203503.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0634\u0648\u064a\u0645\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ash Shuwaymiya"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421203503,
-    "wof:lastmodified":1566672860,
-    "wof:name":"\u0627\u0644\u0634\u0648\u064a\u0645\u064a\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Ash Shuwaymiya",
     "wof:parent_id":1108721081,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/421/204/867/421204867.geojson
+++ b/data/421/204/867/421204867.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632207,
-        85675695,
-        421189275
+        421189275,
+        85675695
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421204867,
-    "wof:lastmodified":1601068401,
+    "wof:lastmodified":1601423091,
     "wof:name":"Nashib",
     "wof:parent_id":421189275,
     "wof:placetype":"locality",

--- a/data/421/204/867/421204867.geojson
+++ b/data/421/204/867/421204867.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0646\u0627\u0634\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Nashib"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421204867,
-    "wof:lastmodified":1566672859,
-    "wof:name":"\u0646\u0627\u0634\u0628",
+    "wof:lastmodified":1601068401,
+    "wof:name":"Nashib",
     "wof:parent_id":421189275,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",

--- a/data/890/449/771/890449771.geojson
+++ b/data/890/449/771/890449771.geojson
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":890449771,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Khasab",
     "wof:parent_id":85675709,
     "wof:placetype":"locality",

--- a/data/890/449/771/890449771.geojson
+++ b/data/890/449/771/890449771.geojson
@@ -18,6 +18,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062e\u0635\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Al Khasab"
+    ],
     "qs:name":"\u0627\u0644\u062e\u0635\u0628",
     "qs:name_adm0":"\u0639\u0645\u0627\u0646",
     "qs:name_adm1":"\u0645\u0633\u0646\u062f\u0645",
@@ -51,8 +57,8 @@
         }
     ],
     "wof:id":890449771,
-    "wof:lastmodified":1566672872,
-    "wof:name":"\u0627\u0644\u062e\u0635\u0628",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Khasab",
     "wof:parent_id":85675709,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-om",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.