### PR TITLE
om concordances, placetype local, and more

### DIFF
--- a/data/110/872/105/1/1108721051.geojson
+++ b/data/110/872/105/1/1108721051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108138,
-    "geom:area_square_m":1232871710.337659,
+    "geom:area_square_m":1232871899.335503,
     "geom:bbox":"58.286838,22.557694,58.722787,22.986543",
     "geom:latitude":22.777223,
     "geom:longitude":58.468089,
@@ -129,9 +129,10 @@
         "hasc:id":"OM.SN.IB",
         "wd:id":"Q1655950"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131177,
-    "wof:geomhash":"14f9c8d3fa76d0eca9a9eb6645cef040",
+    "wof:geomhash":"da2533048165c7db023c1a36f60c3bf7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108721051,
-    "wof:lastmodified":1690850217,
+    "wof:lastmodified":1695886593,
     "wof:name":"Ibra",
     "wof:parent_id":85675721,
     "wof:placetype":"county",

--- a/data/110/872/105/3/1108721053.geojson
+++ b/data/110/872/105/3/1108721053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.826384,
-    "geom:area_square_m":20981900296.29533,
+    "geom:area_square_m":20981899998.017395,
     "geom:bbox":"56.527701,20.898462,58.076736,22.600891",
     "geom:latitude":21.704838,
     "geom:longitude":57.342008,
@@ -111,9 +111,10 @@
         "hasc:id":"OM.DA.AD",
         "wd:id":"Q2823918"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131178,
-    "wof:geomhash":"b2977781c755365d4b21c0d40b7da62b",
+    "wof:geomhash":"e90433435f59a319727cf3550f7a340c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108721053,
-    "wof:lastmodified":1690850217,
+    "wof:lastmodified":1695886593,
     "wof:name":"Adam",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/110/872/105/5/1108721055.geojson
+++ b/data/110/872/105/5/1108721055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.136313,
-    "geom:area_square_m":1554075239.902114,
+    "geom:area_square_m":1554075239.901965,
     "geom:bbox":"57.6210705821,22.450555,58.0073285084,23.0878928152",
     "geom:latitude":22.778262,
     "geom:longitude":57.808801,
@@ -107,9 +107,10 @@
     "wof:concordances":{
         "hasc:id":"OM.DA.IZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131184,
-    "wof:geomhash":"a0b9756d1f8e1c7281a7c556e0849946",
+    "wof:geomhash":"39382ac65683fbd2f99aa8a1369320d0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108721055,
-    "wof:lastmodified":1566672824,
+    "wof:lastmodified":1695886593,
     "wof:name":"Izki",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/110/872/105/7/1108721057.geojson
+++ b/data/110/872/105/7/1108721057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.263671,
-    "geom:area_square_m":2985673622.037207,
+    "geom:area_square_m":2985673622.470804,
     "geom:bbox":"55.417738,23.337031,56.094699,24.056441",
     "geom:latitude":23.686216,
     "geom:longitude":55.735567,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"OM.BU.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131185,
-    "wof:geomhash":"fd7f1c1aea56c2b44089594aced2b87e",
+    "wof:geomhash":"1f39a3544848d34052f4f759cf6d74b3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721057,
-    "wof:lastmodified":1627522486,
+    "wof:lastmodified":1695886121,
     "wof:name":"As Sunaynah",
     "wof:parent_id":85675717,
     "wof:placetype":"county",

--- a/data/110/872/105/9/1108721059.geojson
+++ b/data/110/872/105/9/1108721059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.143135,
-    "geom:area_square_m":1634116517.811733,
+    "geom:area_square_m":1634115913.558047,
     "geom:bbox":"58.42224,22.13,58.932002,22.91312",
     "geom:latitude":22.588151,
     "geom:longitude":58.656839,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"OM.SN.QA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131186,
-    "wof:geomhash":"3737e6deb4c0375317a3f5b18ab1a5c0",
+    "wof:geomhash":"38578e54bd63feb4ec0dbce41af24aad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108721059,
-    "wof:lastmodified":1627522486,
+    "wof:lastmodified":1695886121,
     "wof:name":"Al Qabil",
     "wof:parent_id":85675721,
     "wof:placetype":"county",

--- a/data/110/872/106/3/1108721063.geojson
+++ b/data/110/872/106/3/1108721063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092508,
-    "geom:area_square_m":1057853754.865885,
+    "geom:area_square_m":1057853729.42631,
     "geom:bbox":"58.93713,22.137748,59.369055,22.540992",
     "geom:latitude":22.36257,
     "geom:longitude":59.1764,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"OM.SS.KW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131187,
-    "wof:geomhash":"0d10a33d95443f6968a716de07436a6c",
+    "wof:geomhash":"d02c92d416945ac07d43da7754d9f3ea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721063,
-    "wof:lastmodified":1627522485,
+    "wof:lastmodified":1695886120,
     "wof:name":"Al Kamil Wa Al Wafi",
     "wof:parent_id":85675691,
     "wof:placetype":"county",

--- a/data/110/872/106/5/1108721065.geojson
+++ b/data/110/872/106/5/1108721065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010801,
-    "geom:area_square_m":119970154.346083,
+    "geom:area_square_m":119969719.692171,
     "geom:bbox":"56.087002,25.896049,56.21874,26.230174",
     "geom:latitude":26.073341,
     "geom:longitude":56.16447,
@@ -114,9 +114,10 @@
         "hasc:id":"OM.MU.BU",
         "wd:id":"Q997847"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131189,
-    "wof:geomhash":"afaf99a11b8a14ebcf3c49f77c353a4e",
+    "wof:geomhash":"51a489aff833973e5757b3f2c63d6364",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108721065,
-    "wof:lastmodified":1690850219,
+    "wof:lastmodified":1695886593,
     "wof:name":"Bukha",
     "wof:parent_id":85675709,
     "wof:placetype":"county",

--- a/data/110/872/106/7/1108721067.geojson
+++ b/data/110/872/106/7/1108721067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056359,
-    "geom:area_square_m":639956740.766066,
+    "geom:area_square_m":639956708.873807,
     "geom:bbox":"58.043994,23.050384,58.390161,23.508344",
     "geom:latitude":23.319585,
     "geom:longitude":58.229057,
@@ -183,9 +183,10 @@
         "hasc:id":"OM.DA.BB",
         "wd:id":"Q547202"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131190,
-    "wof:geomhash":"04053731390c029b5c5ae99798cd1d02",
+    "wof:geomhash":"6ef71f9c808e2e50295703672a2d2b20",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":1108721067,
-    "wof:lastmodified":1690850219,
+    "wof:lastmodified":1695886593,
     "wof:name":"Bidbid",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/110/872/106/9/1108721069.geojson
+++ b/data/110/872/106/9/1108721069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.475475,
-    "geom:area_square_m":5461844171.945563,
+    "geom:area_square_m":5461844604.220783,
     "geom:bbox":"58.589499,20.969292,59.711015,22.426646",
     "geom:latitude":21.718902,
     "geom:longitude":59.071706,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"OM.SS.JH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131191,
-    "wof:geomhash":"7ea41f7603fd5563c64e2be883bd7513",
+    "wof:geomhash":"efdaf0f20b2f9a7d96dac8098ed4e3f6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721069,
-    "wof:lastmodified":1627522486,
+    "wof:lastmodified":1695886121,
     "wof:name":"Jaalan Bani Bu Hasan",
     "wof:parent_id":85675691,
     "wof:placetype":"county",

--- a/data/110/872/107/1/1108721071.geojson
+++ b/data/110/872/107/1/1108721071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.267712,
-    "geom:area_square_m":3073062462.794952,
+    "geom:area_square_m":3073061746.89811,
     "geom:bbox":"58.739015,20.9691,59.826221,22.364503",
     "geom:latitude":21.821699,
     "geom:longitude":59.401484,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"OM.SS.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131192,
-    "wof:geomhash":"bb34f7662f1ca4cf1f79417acdd56162",
+    "wof:geomhash":"dac0168fa23524f8292ef574ee9a1d94",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721071,
-    "wof:lastmodified":1627522486,
+    "wof:lastmodified":1695886121,
     "wof:name":"Jaalan Bani Bu Ali",
     "wof:parent_id":85675691,
     "wof:placetype":"county",

--- a/data/110/872/107/3/1108721073.geojson
+++ b/data/110/872/107/3/1108721073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086979,
-    "geom:area_square_m":965907639.337519,
+    "geom:area_square_m":965907845.781597,
     "geom:bbox":"56.174804,25.842354,56.542027,26.505472",
     "geom:latitude":26.091631,
     "geom:longitude":56.319254,
@@ -213,9 +213,10 @@
         "hasc:id":"OM.MU.KH",
         "wd:id":"Q426646"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131193,
-    "wof:geomhash":"5bb959b363fc128a6fdd6cf18e0d715b",
+    "wof:geomhash":"f5f0140ad4c406d0b9c4f3da0e284f79",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -225,7 +226,7 @@
         }
     ],
     "wof:id":1108721073,
-    "wof:lastmodified":1690850219,
+    "wof:lastmodified":1695886593,
     "wof:name":"Khasab",
     "wof:parent_id":85675709,
     "wof:placetype":"county",

--- a/data/110/872/107/5/1108721075.geojson
+++ b/data/110/872/107/5/1108721075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045643,
-    "geom:area_square_m":508225360.764966,
+    "geom:area_square_m":508225360.764867,
     "geom:bbox":"56.1392,25.6023,56.4237520203,25.9466776468",
     "geom:latitude":25.776314,
     "geom:longitude":56.254257,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"OM.MU.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131195,
-    "wof:geomhash":"63e6ee4bae2adb3129fb53bdbe402d25",
+    "wof:geomhash":"a17940b28ec4d43695465dbd461d2801",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108721075,
-    "wof:lastmodified":1566672826,
+    "wof:lastmodified":1695886593,
     "wof:name":"Daba",
     "wof:parent_id":85675709,
     "wof:placetype":"county",

--- a/data/110/872/107/7/1108721077.geojson
+++ b/data/110/872/107/7/1108721077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146931,
-    "geom:area_square_m":1672174064.619857,
+    "geom:area_square_m":1672173668.177314,
     "geom:bbox":"58.340491,22.752133,59.090651,23.245368",
     "geom:latitude":23.018257,
     "geom:longitude":58.665864,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"OM.SN.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131196,
-    "wof:geomhash":"14c83c8c433df8300b2eb372e343cfb1",
+    "wof:geomhash":"bcd42d9bb07ca30e9eacc3e644dfcc8a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721077,
-    "wof:lastmodified":1627522486,
+    "wof:lastmodified":1695886122,
     "wof:name":"Dama Wa At Taiyin",
     "wof:parent_id":85675721,
     "wof:placetype":"county",

--- a/data/110/872/108/1/1108721081.geojson
+++ b/data/110/872/108/1/1108721081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.63904,
-    "geom:area_square_m":19252735399.489304,
+    "geom:area_square_m":19252735190.522533,
     "geom:bbox":"54.142884,17.461486,56.356194,18.951729",
     "geom:latitude":18.200269,
     "geom:longitude":55.283062,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"OM.JA.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131198,
-    "wof:geomhash":"647931dbb3464261bf2a11e4613d509f",
+    "wof:geomhash":"e0c21f859e6eff0b7356452d999d5796",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721081,
-    "wof:lastmodified":1627522487,
+    "wof:lastmodified":1695886123,
     "wof:name":"Shalim Wa Juzor Al Hallaniyat",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/110/872/108/3/1108721083.geojson
+++ b/data/110/872/108/3/1108721083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.132972,
-    "geom:area_square_m":1502622359.811327,
+    "geom:area_square_m":1502622384.025005,
     "geom:bbox":"56.555485,23.597033,57.054506,24.239812",
     "geom:latitude":23.952703,
     "geom:longitude":56.789803,
@@ -183,9 +183,10 @@
         "hasc:id":"OM.BN.SA",
         "wd:id":"Q3461496"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131200,
-    "wof:geomhash":"354873df63a9a23e6466a3eac42ca39d",
+    "wof:geomhash":"bf0ddabfffb730385b7edb7ac26e2b0e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -195,7 +196,7 @@
         }
     ],
     "wof:id":1108721083,
-    "wof:lastmodified":1690850220,
+    "wof:lastmodified":1695886593,
     "wof:name":"Saham",
     "wof:parent_id":85675703,
     "wof:placetype":"county",

--- a/data/110/872/108/5/1108721085.geojson
+++ b/data/110/872/108/5/1108721085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170566,
-    "geom:area_square_m":1931672102.899731,
+    "geom:area_square_m":1931672853.894599,
     "geom:bbox":"55.965154,23.357528,56.58557,24.013653",
     "geom:latitude":23.667668,
     "geom:longitude":56.23005,
@@ -90,9 +90,10 @@
         "hasc:id":"OM.DH.DA",
         "wd:id":"Q6406928"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131201,
-    "wof:geomhash":"743e11062f849a321e80efdeedee74cb",
+    "wof:geomhash":"3cdb1cf86e5308e2e958b6760af637d5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108721085,
-    "wof:lastmodified":1627522486,
+    "wof:lastmodified":1695886122,
     "wof:name":"Dank",
     "wof:parent_id":85675699,
     "wof:placetype":"county",

--- a/data/110/872/108/7/1108721087.geojson
+++ b/data/110/872/108/7/1108721087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042839,
-    "geom:area_square_m":486035790.510844,
+    "geom:area_square_m":486035831.644959,
     "geom:bbox":"57.672053,23.161678,57.98833,23.592215",
     "geom:latitude":23.430781,
     "geom:longitude":57.796729,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"OM.BS.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131202,
-    "wof:geomhash":"5c903227ec6c80e2e9542453e532767b",
+    "wof:geomhash":"280626b09eb0eb2845263c28d6d26707",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108721087,
-    "wof:lastmodified":1627522488,
+    "wof:lastmodified":1695886124,
     "wof:name":"Wadi Al Maawil",
     "wof:parent_id":85675727,
     "wof:placetype":"county",

--- a/data/110/872/108/9/1108721089.geojson
+++ b/data/110/872/108/9/1108721089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076857,
-    "geom:area_square_m":877149895.767854,
+    "geom:area_square_m":877149848.827023,
     "geom:bbox":"58.839035,22.486795,59.230122,22.81767",
     "geom:latitude":22.63439,
     "geom:longitude":59.017094,
@@ -117,9 +117,10 @@
         "hasc:id":"OM.SN.WK",
         "wd:id":"Q6398583"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131203,
-    "wof:geomhash":"1c16e60bf0a1f0ea96fbe0840af9bb28",
+    "wof:geomhash":"eb0323f586bd31de0266beb31526af81",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1108721089,
-    "wof:lastmodified":1690850220,
+    "wof:lastmodified":1695886124,
     "wof:name":"Wadi Bani Khalid",
     "wof:parent_id":85675721,
     "wof:placetype":"county",

--- a/data/110/872/109/1/1108721091.geojson
+++ b/data/110/872/109/1/1108721091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081941,
-    "geom:area_square_m":929976992.574098,
+    "geom:area_square_m":929976695.310633,
     "geom:bbox":"57.59737,23.119191,58.080801,23.592214",
     "geom:latitude":23.38677,
     "geom:longitude":57.807059,
@@ -114,9 +114,10 @@
         "hasc:id":"OM.BS.NA",
         "wd:id":"Q2643322"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131204,
-    "wof:geomhash":"3f3a08632e016d5c6deef07a99dbacb4",
+    "wof:geomhash":"d044dc116d59ebfe9cbb688e040ad2fa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108721091,
-    "wof:lastmodified":1690850218,
+    "wof:lastmodified":1695886593,
     "wof:name":"Nakhal",
     "wof:parent_id":85675727,
     "wof:placetype":"county",

--- a/data/110/872/109/3/1108721093.geojson
+++ b/data/110/872/109/3/1108721093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008004,
-    "geom:area_square_m":89498576.822736,
+    "geom:area_square_m":89498413.294103,
     "geom:bbox":"56.207978,25.227219,56.351526,25.330452",
     "geom:latitude":25.276292,
     "geom:longitude":56.279652,
@@ -172,12 +172,13 @@
         "hasc:id":"OM.MU.MA",
         "wd:id":"Q1883385"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131205,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"82966f19c023f5ec07dfa4d4fe4626fd",
+    "wof:geomhash":"32817c59f12d5904d195c44645c84b36",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":1108721093,
-    "wof:lastmodified":1690850218,
+    "wof:lastmodified":1695886699,
     "wof:name":"Madha",
     "wof:parent_id":85675709,
     "wof:placetype":"county",

--- a/data/110/872/109/5/1108721095.geojson
+++ b/data/110/872/109/5/1108721095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008107,
-    "geom:area_square_m":91862764.565163,
+    "geom:area_square_m":91862685.476831,
     "geom:bbox":"58.472814,23.531037,58.592369,23.680416",
     "geom:latitude":23.591427,
     "geom:longitude":58.537623,
@@ -207,9 +207,10 @@
         "hasc:id":"OM.MA.MT",
         "wd:id":"Q1166791"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131206,
-    "wof:geomhash":"b8cf476db482b28d2fd0e3ca05b71c41",
+    "wof:geomhash":"72a8bb423007813c10a1be6c8c255129",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -219,7 +220,7 @@
         }
     ],
     "wof:id":1108721095,
-    "wof:lastmodified":1690850219,
+    "wof:lastmodified":1695886593,
     "wof:name":"Mutrah",
     "wof:parent_id":85675713,
     "wof:placetype":"county",

--- a/data/110/872/109/9/1108721099.geojson
+++ b/data/110/872/109/9/1108721099.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065712,
-    "geom:area_square_m":739565742.204977,
+    "geom:area_square_m":739565812.69793,
     "geom:bbox":"56.194674,24.309149,56.617545,24.602867",
     "geom:latitude":24.468893,
     "geom:longitude":56.406232,
@@ -99,9 +99,10 @@
         "hasc:id":"OM.BN.LI",
         "wd:id":"Q4165487"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131207,
-    "wof:geomhash":"7d8265f9fda61ae7f888c19e0b5db43d",
+    "wof:geomhash":"4d491618c5a5c53a7c008555af5f979f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108721099,
-    "wof:lastmodified":1690850218,
+    "wof:lastmodified":1695886123,
     "wof:name":"Liwa",
     "wof:parent_id":85675703,
     "wof:placetype":"county",

--- a/data/110/872/110/1/1108721101.geojson
+++ b/data/110/872/110/1/1108721101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111494,
-    "geom:area_square_m":1261929403.283122,
+    "geom:area_square_m":1261929027.92666,
     "geom:bbox":"56.199223,23.527426,56.601354,23.978969",
     "geom:latitude":23.745627,
     "geom:longitude":56.40192,
@@ -90,9 +90,10 @@
         "hasc:id":"OM.DH.YA",
         "wd:id":"Q6390074"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1476131208,
-    "wof:geomhash":"dec12d885d55817af06714eb5bd769f6",
+    "wof:geomhash":"b887855cf42210959217a3d9adab83e8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108721101,
-    "wof:lastmodified":1690850218,
+    "wof:lastmodified":1695886124,
     "wof:name":"Yanqul",
     "wof:parent_id":85675699,
     "wof:placetype":"county",

--- a/data/151/183/838/9/1511838389.geojson
+++ b/data/151/183/838/9/1511838389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.203252,
-    "geom:area_square_m":20981900296.29533,
+    "geom:area_square_m":14134987060.835091,
     "geom:bbox":"52.0,16.929335,53.401392,19.206678",
     "geom:latitude":18.223294,
     "geom:longitude":52.691355,
@@ -62,8 +62,9 @@
         "hasc:id":"OM.JA.MZ",
         "wd:id":"Q65041555"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
-    "wof:geomhash":"f11b4c9eae16258a72310edbb03ac40d",
+    "wof:geomhash":"2ac1b067c40af573b1b6ead8d5e5d37e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -73,7 +74,7 @@
         }
     ],
     "wof:id":1511838389,
-    "wof:lastmodified":1627522485,
+    "wof:lastmodified":1695886120,
     "wof:name":"Al-Mazyona",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/151/183/839/1/1511838391.geojson
+++ b/data/151/183/839/1/1511838391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05281,
-    "geom:area_square_m":20981900296.29533,
+    "geom:area_square_m":600403499.910612,
     "geom:bbox":"57.077506,23.027741,57.441904,23.290567",
     "geom:latitude":23.154468,
     "geom:longitude":57.245083,
@@ -93,8 +93,9 @@
         "hasc:id":"OM.DA.HA",
         "wd:id":"Q2829338"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
-    "wof:geomhash":"92231128c46a3c076cd75abe5f1494fd",
+    "wof:geomhash":"660319659374c1f7b8fe913b8dc4374b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1511838391,
-    "wof:lastmodified":1690850212,
+    "wof:lastmodified":1695886120,
     "wof:name":"Al-Hamra",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/421/169/317/421169317.geojson
+++ b/data/421/169/317/421169317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036428,
-    "geom:area_square_m":413788632.750576,
+    "geom:area_square_m":413788666.897292,
     "geom:bbox":"57.464925,23.149761,57.693077,23.428569",
     "geom:latitude":23.274486,
     "geom:longitude":57.571524,
@@ -107,12 +107,13 @@
         "hasc:id":"OM.BS.AW",
         "qs_pg:id":776481
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459008804,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"55920edd0ff776de2518884b35177b9b",
+    "wof:geomhash":"fb64c041e5445b70ca67ec51d801a498",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":421169317,
-    "wof:lastmodified":1627522485,
+    "wof:lastmodified":1695886119,
     "wof:name":"Al Awabi",
     "wof:parent_id":85675727,
     "wof:placetype":"county",

--- a/data/421/170/285/421170285.geojson
+++ b/data/421/170/285/421170285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.420405,
-    "geom:area_square_m":16574128840.084793,
+    "geom:area_square_m":16574128466.510818,
     "geom:bbox":"53.769977,18.458778,55.686817,19.999712",
     "geom:latitude":19.308735,
     "geom:longitude":54.744359,
@@ -98,12 +98,13 @@
         "hasc:id":"OM.JA.MU",
         "qs_pg:id":233880
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459008846,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de2d7817ad848f7909e6504543ea465a",
+    "wof:geomhash":"27d73b1f9d2d044b4bccbc481a3d2cb0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421170285,
-    "wof:lastmodified":1627522487,
+    "wof:lastmodified":1695886122,
     "wof:name":"Muqshin",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/172/085/421172085.geojson
+++ b/data/421/172/085/421172085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.141952,
-    "geom:area_square_m":1679545877.087872,
+    "geom:area_square_m":1679546219.384849,
     "geom:bbox":"53.12948,16.731509,53.752051,17.100197",
     "geom:latitude":16.890125,
     "geom:longitude":53.421873,
@@ -107,12 +107,13 @@
         "hasc:id":"OM.JA.RA",
         "qs_pg:id":1295827
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459008919,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"94e0593652df0f65347d6869e28e6e22",
+    "wof:geomhash":"8a643eef58344167a3f179439df4b775",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":421172085,
-    "wof:lastmodified":1627522487,
+    "wof:lastmodified":1695886122,
     "wof:name":"Rakhyut",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/172/087/421172087.geojson
+++ b/data/421/172/087/421172087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.596355,
-    "geom:area_square_m":6989461078.872658,
+    "geom:area_square_m":6989461667.570186,
     "geom:bbox":"55.769648,17.929479,56.743176,19.120194",
     "geom:latitude":18.584368,
     "geom:longitude":56.312229,
@@ -120,12 +120,13 @@
         "qs_pg:id":1295828,
         "wd:id":"Q6418090"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459008920,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4d54d2de8d1ce54bc36cffdfac807727",
+    "wof:geomhash":"868e6f5c68682bd61bf926808c38ee77",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421172087,
-    "wof:lastmodified":1690850224,
+    "wof:lastmodified":1695886120,
     "wof:name":"Al Jazir",
     "wof:parent_id":85675685,
     "wof:placetype":"county",

--- a/data/421/175/629/421175629.geojson
+++ b/data/421/175/629/421175629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.166505,
-    "geom:area_square_m":1901238369.426596,
+    "geom:area_square_m":1901238029.162339,
     "geom:bbox":"59.015268,22.226064,59.837917,22.883213",
     "geom:latitude":22.565124,
     "geom:longitude":59.417467,
@@ -240,12 +240,13 @@
         "qs_pg:id":383459,
         "wd:id":"Q737270"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009074,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"456d0c8c586c58025a49d14a3b396e7b",
+    "wof:geomhash":"2ca82d3f3343881682133583c4e0cf2d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -255,7 +256,7 @@
         }
     ],
     "wof:id":421175629,
-    "wof:lastmodified":1690850225,
+    "wof:lastmodified":1695886723,
     "wof:name":"Sur",
     "wof:parent_id":85675691,
     "wof:placetype":"county",

--- a/data/421/175/631/421175631.geojson
+++ b/data/421/175/631/421175631.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05807,
-    "geom:area_square_m":672967114.739751,
+    "geom:area_square_m":672967114.874321,
     "geom:bbox":"58.598721,20.158722,58.96125,20.697056",
     "geom:latitude":20.411095,
     "geom:longitude":58.776762,
@@ -198,12 +198,13 @@
         "qs_pg:id":383462,
         "wd:id":"Q1793853"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009074,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aff3a50ed570c5eeb2db1c0cbef01839",
+    "wof:geomhash":"85fa9f0b54e496c92419134932fd5e47",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -213,7 +214,7 @@
         }
     ],
     "wof:id":421175631,
-    "wof:lastmodified":1690850225,
+    "wof:lastmodified":1695886699,
     "wof:name":"Masirah",
     "wof:parent_id":85675691,
     "wof:placetype":"county",

--- a/data/421/183/959/421183959.geojson
+++ b/data/421/183/959/421183959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.093831,
-    "geom:area_square_m":1053961419.53376,
+    "geom:area_square_m":1053961536.66627,
     "geom:bbox":"56.17695,24.535123,56.552364,24.981369",
     "geom:latitude":24.713982,
     "geom:longitude":56.343866,
@@ -135,12 +135,13 @@
         "qs_pg:id":986740,
         "wd:id":"Q3482179"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009396,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a3722c7110a8e401183491dd7175b128",
+    "wof:geomhash":"f4705fe6f14a3a0ffb251fc770745967",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421183959,
-    "wof:lastmodified":1690850227,
+    "wof:lastmodified":1695886700,
     "wof:name":"Shinas",
     "wof:parent_id":85675703,
     "wof:placetype":"county",

--- a/data/421/184/219/421184219.geojson
+++ b/data/421/184/219/421184219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088728,
-    "geom:area_square_m":1004125919.845066,
+    "geom:area_square_m":1004125418.602148,
     "geom:bbox":"57.041131,23.565626,57.536074,23.946758",
     "geom:latitude":23.762739,
     "geom:longitude":57.266512,
@@ -98,12 +98,13 @@
         "hasc:id":"OM.BN.SU",
         "qs_pg:id":991471
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009404,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a0e69c185a30fc1f1a54b9e488b5271f",
+    "wof:geomhash":"f9670d3a3435c7ed27bb0f5007774227",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421184219,
-    "wof:lastmodified":1627522487,
+    "wof:lastmodified":1695886122,
     "wof:name":"As Suwayq",
     "wof:parent_id":85675703,
     "wof:placetype":"county",

--- a/data/421/184/221/421184221.geojson
+++ b/data/421/184/221/421184221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.126915,
-    "geom:area_square_m":13036699638.341282,
+    "geom:area_square_m":13036699929.459507,
     "geom:bbox":"57.279518,19.835703,58.807083,21.454098",
     "geom:latitude":20.676912,
     "geom:longitude":58.000919,
@@ -98,12 +98,13 @@
         "hasc:id":"OM.WU.MU",
         "qs_pg:id":991472
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009404,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4f59534556209eef96c0e5a6ccefe541",
+    "wof:geomhash":"a2602f861e7e720e84f8165fde8d9fb4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421184221,
-    "wof:lastmodified":1627522487,
+    "wof:lastmodified":1695886122,
     "wof:name":"Mahawt",
     "wof:parent_id":85675685,
     "wof:placetype":"county",

--- a/data/421/184/225/421184225.geojson
+++ b/data/421/184/225/421184225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108645,
-    "geom:area_square_m":1226678949.792559,
+    "geom:area_square_m":1226678535.221135,
     "geom:bbox":"55.729067,23.783754,56.402688,24.326795",
     "geom:latitude":24.061914,
     "geom:longitude":56.07019,
@@ -165,12 +165,13 @@
         "qs_pg:id":991473,
         "wd:id":"Q2829307"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009404,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"49d113d0c03b69fc4b4ae37fe6e5a50d",
+    "wof:geomhash":"140f243dcbbb8ffa7029b316b9497e76",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":421184225,
-    "wof:lastmodified":1690850227,
+    "wof:lastmodified":1695886700,
     "wof:name":"Al Buraymi",
     "wof:parent_id":85675717,
     "wof:placetype":"county",

--- a/data/421/184/227/421184227.geojson
+++ b/data/421/184/227/421184227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.131491,
-    "geom:area_square_m":36739791117.830566,
+    "geom:area_square_m":36739791776.411316,
     "geom:bbox":"52.620907,17.211627,54.770329,19.589842",
     "geom:latitude":18.396004,
     "geom:longitude":53.706131,
@@ -98,12 +98,13 @@
         "hasc:id":"OM.JA.TH",
         "qs_pg:id":991474
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009404,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f9aa12cacb4e86f4a4add016fa84d22f",
+    "wof:geomhash":"7facc133960b80d26a04ccbe12c26943",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421184227,
-    "wof:lastmodified":1627522488,
+    "wof:lastmodified":1695886123,
     "wof:name":"Thumrayt",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/184/415/421184415.geojson
+++ b/data/421/184/415/421184415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.806216,
-    "geom:area_square_m":9410324736.963566,
+    "geom:area_square_m":9410325380.93392,
     "geom:bbox":"56.490132,18.686908,57.847916,20.004862",
     "geom:latitude":19.270808,
     "geom:longitude":57.273585,
@@ -98,12 +98,13 @@
         "hasc:id":"OM.WU.DU",
         "qs_pg:id":996312
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009410,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c82174b6932a3b828fe67cf8f324e496",
+    "wof:geomhash":"a4ce73948d8e2c265152e6adec850022",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421184415,
-    "wof:lastmodified":1627522486,
+    "wof:lastmodified":1695886120,
     "wof:name":"Ad Duqm",
     "wof:parent_id":85675685,
     "wof:placetype":"county",

--- a/data/421/184/531/421184531.geojson
+++ b/data/421/184/531/421184531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.291058,
-    "geom:area_square_m":3274329662.953641,
+    "geom:area_square_m":3274329465.668248,
     "geom:bbox":"55.765337,24.062897,56.339188,25.005936",
     "geom:latitude":24.522339,
     "geom:longitude":56.020865,
@@ -98,12 +98,13 @@
         "hasc:id":"OM.BU.MA",
         "qs_pg:id":1001207
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009414,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05e378214f652ed86bf76e62f440ef42",
+    "wof:geomhash":"1f4a42c9a6d9bc8c59d7a0e4073f05d6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421184531,
-    "wof:lastmodified":1627522487,
+    "wof:lastmodified":1695886123,
     "wof:name":"Mahadah",
     "wof:parent_id":85675717,
     "wof:placetype":"county",

--- a/data/421/185/083/421185083.geojson
+++ b/data/421/185/083/421185083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149475,
-    "geom:area_square_m":1698907847.724129,
+    "geom:area_square_m":1698907524.862313,
     "geom:bbox":"57.786481,22.969337,58.292643,23.44987",
     "geom:latitude":23.193597,
     "geom:longitude":58.03358,
@@ -198,12 +198,13 @@
         "qs_pg:id":1017967,
         "wd:id":"Q3470608"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009432,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eb96e2e642ef6c108e5293f28deac4d3",
+    "wof:geomhash":"eee9504d05659b717ba017d6f89dec3e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -213,7 +214,7 @@
         }
     ],
     "wof:id":421185083,
-    "wof:lastmodified":1690850228,
+    "wof:lastmodified":1695886700,
     "wof:name":"Samail",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/421/185/635/421185635.geojson
+++ b/data/421/185/635/421185635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023437,
-    "geom:area_square_m":265829212.216297,
+    "geom:area_square_m":265829135.683198,
     "geom:bbox":"58.578892,23.364044,58.837847,23.626249",
     "geom:latitude":23.468018,
     "geom:longitude":58.700748,
@@ -467,12 +467,13 @@
         "hasc:id":"OM.MA.MS",
         "qs_pg:id":899372
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009449,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0bf7dc4a643dd2b1e8a2904f5e51b393",
+    "wof:geomhash":"6964679715f1ccfc6c7999ff9bc7a675",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -482,7 +483,7 @@
         }
     ],
     "wof:id":421185635,
-    "wof:lastmodified":1636496574,
+    "wof:lastmodified":1695886724,
     "wof:name":"Muscat",
     "wof:parent_id":85675713,
     "wof:placetype":"county",

--- a/data/421/186/553/421186553.geojson
+++ b/data/421/186/553/421186553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134866,
-    "geom:area_square_m":1533634427.419493,
+    "geom:area_square_m":1533634427.419504,
     "geom:bbox":"58.6191854797,22.840230972,59.224609375,23.4283230158",
     "geom:latitude":23.125607,
     "geom:longitude":58.902824,
@@ -321,12 +321,13 @@
         "qs_pg:id":1073977,
         "wd:id":"Q3414795"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009484,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"df28eea7f7512da5fa19cb47c2f81d54",
+    "wof:geomhash":"ee9dad0efb5b66283d3e0c80b4993e8d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -336,7 +337,7 @@
         }
     ],
     "wof:id":421186553,
-    "wof:lastmodified":1582321497,
+    "wof:lastmodified":1695886699,
     "wof:name":"Qurayyat",
     "wof:parent_id":85675713,
     "wof:placetype":"county",

--- a/data/421/186/667/421186667.geojson
+++ b/data/421/186/667/421186667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.127951,
-    "geom:area_square_m":1456648458.601821,
+    "geom:area_square_m":1456648088.100528,
     "geom:bbox":"57.340502,22.687738,57.806356,23.181254",
     "geom:latitude":22.973439,
     "geom:longitude":57.552275,
@@ -243,12 +243,13 @@
         "qs_pg:id":1090199,
         "wd:id":"Q1915327"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009488,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e736ca11e88d8daedf6fe804874d0dc0",
+    "wof:geomhash":"3358af12758a307686b67784d549abc8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -258,7 +259,7 @@
         }
     ],
     "wof:id":421186667,
-    "wof:lastmodified":1690850224,
+    "wof:lastmodified":1695886723,
     "wof:name":"Nizwa",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/421/186/703/421186703.geojson
+++ b/data/421/186/703/421186703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072961,
-    "geom:area_square_m":862358665.035155,
+    "geom:area_square_m":862358743.652396,
     "geom:bbox":"54.424496,16.936222,54.871606,17.216562",
     "geom:latitude":17.085423,
     "geom:longitude":54.666575,
@@ -177,12 +177,13 @@
         "qs_pg:id":1090201,
         "wd:id":"Q1938064"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009489,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"39d8b60d39a0aeb4b1300144fc5e39c9",
+    "wof:geomhash":"0b42cd9b6010284d3548a039ce85ede4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":421186703,
-    "wof:lastmodified":1636496573,
+    "wof:lastmodified":1695886723,
     "wof:name":"Mirbat",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/187/061/421187061.geojson
+++ b/data/421/187/061/421187061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042453,
-    "geom:area_square_m":481108036.349624,
+    "geom:area_square_m":481108210.88522,
     "geom:bbox":"58.062051,23.454759,58.331185,23.86039",
     "geom:latitude":23.579807,
     "geom:longitude":58.184979,
@@ -98,12 +98,13 @@
         "hasc:id":"OM.MA.SE",
         "qs_pg:id":1079194
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009500,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0244c221faa0713b1b8678d132dd410",
+    "wof:geomhash":"b3a5879a4ba20fc54c020f6cf96f12d8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421187061,
-    "wof:lastmodified":1627522487,
+    "wof:lastmodified":1695886123,
     "wof:name":"As Seeb",
     "wof:parent_id":85675713,
     "wof:placetype":"county",

--- a/data/421/187/063/421187063.geojson
+++ b/data/421/187/063/421187063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.871036,
-    "geom:area_square_m":32780459430.513554,
+    "geom:area_square_m":32780456860.17931,
     "geom:bbox":"55.21335,21.340868,57.142504,23.727186",
     "geom:latitude":22.572834,
     "geom:longitude":56.123383,
@@ -167,12 +167,13 @@
         "hasc:id":"OM.DH.IB",
         "qs_pg:id":1079195
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009500,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3a59eafef027988930ae242c58fa91d4",
+    "wof:geomhash":"2f99a63d0ed5b53414f0c0aa0a609445",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":421187063,
-    "wof:lastmodified":1636496573,
+    "wof:lastmodified":1695886723,
     "wof:name":"Ibri",
     "wof:parent_id":85675699,
     "wof:placetype":"county",

--- a/data/421/189/275/421189275.geojson
+++ b/data/421/189/275/421189275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089138,
-    "geom:area_square_m":1052763426.468157,
+    "geom:area_square_m":1052763096.020427,
     "geom:bbox":"54.2359,17.030817,54.657475,17.403186",
     "geom:latitude":17.227574,
     "geom:longitude":54.443421,
@@ -120,12 +120,13 @@
         "qs_pg:id":1111547,
         "wd:id":"Q1023534"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009615,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f53d496d0ebbe93bcd6f18b54ca86365",
+    "wof:geomhash":"d0cfd8e0fcf9eee31331d7685d3c54aa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421189275,
-    "wof:lastmodified":1690850223,
+    "wof:lastmodified":1695886699,
     "wof:name":"Taqah",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/189/277/421189277.geojson
+++ b/data/421/189/277/421189277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059012,
-    "geom:area_square_m":698428522.101583,
+    "geom:area_square_m":698427580.375991,
     "geom:bbox":"52.930649,16.650084,53.348521,17.081828",
     "geom:latitude":16.868696,
     "geom:longitude":53.091456,
@@ -123,12 +123,13 @@
         "qs_pg:id":1111548,
         "wd:id":"Q826618"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009616,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f91d3e4a649881c7f7a455a8353c41a2",
+    "wof:geomhash":"b8ec0f6529fba97ab2c18b1a29385e53",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421189277,
-    "wof:lastmodified":1690850223,
+    "wof:lastmodified":1695886120,
     "wof:name":"Dalkut",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/189/279/421189279.geojson
+++ b/data/421/189/279/421189279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.395161,
-    "geom:area_square_m":4507212102.824023,
+    "geom:area_square_m":4507212406.559701,
     "geom:bbox":"56.759028,22.240021,57.51317,23.214932",
     "geom:latitude":22.71495,
     "geom:longitude":57.098964,
@@ -165,12 +165,13 @@
         "qs_pg:id":1111550,
         "wd:id":"Q800253"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009616,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8498c92d3b0b2546bd1c186edff30e49",
+    "wof:geomhash":"558b2ce17c1b899353fca6a23f6898c8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":421189279,
-    "wof:lastmodified":1690850223,
+    "wof:lastmodified":1695886700,
     "wof:name":"Bahla",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/421/189/283/421189283.geojson
+++ b/data/421/189/283/421189283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.599895,
-    "geom:area_square_m":53366489503.992027,
+    "geom:area_square_m":53366484812.230125,
     "geom:bbox":"54.999137,18.714746,57.526138,21.49002",
     "geom:latitude":20.215268,
     "geom:longitude":56.230949,
@@ -98,12 +98,13 @@
         "hasc:id":"OM.WU.HA",
         "qs_pg:id":1111553
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009616,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d81039cf0a968dd0a1ed6a85746a78ef",
+    "wof:geomhash":"400bfce90c8b824820af44aafe6c1f3d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421189283,
-    "wof:lastmodified":1627522486,
+    "wof:lastmodified":1695886121,
     "wof:name":"Hayma",
     "wof:parent_id":85675685,
     "wof:placetype":"county",

--- a/data/421/189/285/421189285.geojson
+++ b/data/421/189/285/421189285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04129,
-    "geom:area_square_m":470941784.73269,
+    "geom:area_square_m":470941822.470707,
     "geom:bbox":"57.47904,22.546574,57.732829,22.884005",
     "geom:latitude":22.719492,
     "geom:longitude":57.596786,
@@ -114,12 +114,13 @@
         "qs_pg:id":1111558,
         "wd:id":"Q6746764"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009616,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"92adfe9276372755521b0856129e5459",
+    "wof:geomhash":"2400d9b5ee6e5e4aeaf336cfca998e35",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421189285,
-    "wof:lastmodified":1690850224,
+    "wof:lastmodified":1695886123,
     "wof:name":"Manah",
     "wof:parent_id":85675681,
     "wof:placetype":"county",

--- a/data/421/195/037/421195037.geojson
+++ b/data/421/195/037/421195037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1785,
-    "geom:area_square_m":2013421614.678419,
+    "geom:area_square_m":2013422520.326717,
     "geom:bbox":"56.279532,23.829447,56.843269,24.512519",
     "geom:latitude":24.186563,
     "geom:longitude":56.532516,
@@ -240,12 +240,13 @@
         "qs_pg:id":169506,
         "wd:id":"Q943270"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009829,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e402ad12045d1eec6beaf823906edb8",
+    "wof:geomhash":"d43b48010ef08834ba20dd339ad1dab4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -255,7 +256,7 @@
         }
     ],
     "wof:id":421195037,
-    "wof:lastmodified":1690850220,
+    "wof:lastmodified":1695886699,
     "wof:name":"Sohar",
     "wof:parent_id":85675703,
     "wof:placetype":"county",

--- a/data/421/195/841/421195841.geojson
+++ b/data/421/195/841/421195841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.059594,
-    "geom:area_square_m":12140198210.904583,
+    "geom:area_square_m":12140198820.876728,
     "geom:bbox":"57.662942,21.160056,58.759186,23.124507",
     "geom:latitude":22.086989,
     "geom:longitude":58.250217,
@@ -98,12 +98,13 @@
         "hasc:id":"OM.SN.MU",
         "qs_pg:id":128064
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009861,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"887c91a4477d87677c01bc7b3544c13b",
+    "wof:geomhash":"9da9ff0956bee3564c7278739f487de4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421195841,
-    "wof:lastmodified":1627522485,
+    "wof:lastmodified":1695886119,
     "wof:name":"Al Mudaybi",
     "wof:parent_id":85675721,
     "wof:placetype":"county",

--- a/data/421/195/843/421195843.geojson
+++ b/data/421/195/843/421195843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13915,
-    "geom:area_square_m":1574081865.90875,
+    "geom:area_square_m":1574082031.730824,
     "geom:bbox":"56.521837,23.531133,57.162589,24.041703",
     "geom:latitude":23.816959,
     "geom:longitude":56.913808,
@@ -98,12 +98,13 @@
         "hasc:id":"OM.BN.KH",
         "qs_pg:id":128066
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459009861,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0100097bb91e5c568d774919a6428cda",
+    "wof:geomhash":"b6ce3858a24e25a8017f1162e3dc175b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421195843,
-    "wof:lastmodified":1627522485,
+    "wof:lastmodified":1695886119,
     "wof:name":"Al Khaburah",
     "wof:parent_id":85675703,
     "wof:placetype":"county",

--- a/data/421/200/933/421200933.geojson
+++ b/data/421/200/933/421200933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094152,
-    "geom:area_square_m":1068742729.767833,
+    "geom:area_square_m":1068742661.028113,
     "geom:bbox":"58.306742,23.156827,58.661453,23.574208",
     "geom:latitude":23.36415,
     "geom:longitude":58.505997,
@@ -98,12 +98,13 @@
         "hasc:id":"OM.MA.AM",
         "qs_pg:id":900287
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459010046,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e0cb38ac8ffd8bedd6f4871d84cb10bb",
+    "wof:geomhash":"e62490e96f64f62f73e9ae20ab7efc86",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421200933,
-    "wof:lastmodified":1627522485,
+    "wof:lastmodified":1695886120,
     "wof:name":"Al Amrat",
     "wof:parent_id":85675713,
     "wof:placetype":"county",

--- a/data/421/200/935/421200935.geojson
+++ b/data/421/200/935/421200935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030035,
-    "geom:area_square_m":340570031.592793,
+    "geom:area_square_m":340570187.559003,
     "geom:bbox":"58.244962,23.369071,58.492008,23.621222",
     "geom:latitude":23.504479,
     "geom:longitude":58.3583,
@@ -147,12 +147,13 @@
         "qs_pg:id":900288,
         "wd:id":"Q2892151"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459010046,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1dac654dd42ed6fcb8f6e4ab57bd8ca8",
+    "wof:geomhash":"8dbca340fe4d0fb22a0b57bf397dcc61",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":421200935,
-    "wof:lastmodified":1690850226,
+    "wof:lastmodified":1695886700,
     "wof:name":"Bawshar",
     "wof:parent_id":85675713,
     "wof:placetype":"county",

--- a/data/421/200/937/421200937.geojson
+++ b/data/421/200/937/421200937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.317176,
-    "geom:area_square_m":3633065909.207191,
+    "geom:area_square_m":3633066838.167565,
     "geom:bbox":"58.532963,21.592213,59.052195,22.679619",
     "geom:latitude":22.126715,
     "geom:longitude":58.824302,
@@ -129,12 +129,13 @@
         "qs_pg:id":900289,
         "wd:id":"Q4904193"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459010046,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"82f64575eac7bf38f9c910f98c3abc94",
+    "wof:geomhash":"6f1e6217937161be40598976f859429c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421200937,
-    "wof:lastmodified":1690850226,
+    "wof:lastmodified":1695886121,
     "wof:name":"Bidiyah",
     "wof:parent_id":85675721,
     "wof:placetype":"county",

--- a/data/421/200/939/421200939.geojson
+++ b/data/421/200/939/421200939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.420615,
-    "geom:area_square_m":4968492401.575013,
+    "geom:area_square_m":4968492116.009212,
     "geom:bbox":"52.976429,16.853315,54.671816,17.636991",
     "geom:latitude":17.195464,
     "geom:longitude":53.857933,
@@ -267,12 +267,13 @@
         "qs_pg:id":900290,
         "wd:id":"Q1294439"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459010046,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0e2fc0440a4fb06e90c9c34a964be724",
+    "wof:geomhash":"efe043a44e6b10ffe49266cb154d61cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -282,7 +283,7 @@
         }
     ],
     "wof:id":421200939,
-    "wof:lastmodified":1690850226,
+    "wof:lastmodified":1695886700,
     "wof:name":"Salalah",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/421/200/941/421200941.geojson
+++ b/data/421/200/941/421200941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.199846,
-    "geom:area_square_m":2267145092.502418,
+    "geom:area_square_m":2267144859.252547,
     "geom:bbox":"57.010072,23.153012,57.645223,23.684235",
     "geom:latitude":23.443289,
     "geom:longitude":57.334475,
@@ -98,12 +98,13 @@
         "hasc:id":"OM.BS.RU",
         "qs_pg:id":900291
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459010046,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"341dcd51a2473f250f6d8b07900dc944",
+    "wof:geomhash":"0eb78b9acfc4403dd657e0c3a7cc5d51",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421200941,
-    "wof:lastmodified":1627522487,
+    "wof:lastmodified":1695886123,
     "wof:name":"Ar Rustaq",
     "wof:parent_id":85675727,
     "wof:placetype":"county",

--- a/data/421/203/283/421203283.geojson
+++ b/data/421/203/283/421203283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.266962,
-    "geom:area_square_m":3151584445.745063,
+    "geom:area_square_m":3151584276.617482,
     "geom:bbox":"54.614428,16.958694,55.305416,17.590005",
     "geom:latitude":17.306378,
     "geom:longitude":54.956415,
@@ -126,12 +126,13 @@
         "qs_pg:id":230856,
         "wd:id":"Q677777"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1459010146,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"577f86928d70ad90c88894bf6193733c",
+    "wof:geomhash":"9545baa265e5c345d2a2880524f80e00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421203283,
-    "wof:lastmodified":1690850222,
+    "wof:lastmodified":1695886723,
     "wof:name":"Sadah",
     "wof:parent_id":85675695,
     "wof:placetype":"county",

--- a/data/856/322/07/85632207.geojson
+++ b/data/856/322/07/85632207.geojson
@@ -1107,6 +1107,7 @@
         "hasc:id":"OM",
         "icao:code":"A40",
         "ioc:id":"OMA",
+        "iso:code":"OM",
         "itu:id":"OMA",
         "loc:id":"n81035932",
         "m49:code":"512",
@@ -1120,6 +1121,7 @@
         "wk:page":"Oman",
         "wmo:id":"OM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"OM",
     "wof:country_alpha3":"OMN",
     "wof:geom_alt":[
@@ -1142,7 +1144,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639517,
+    "wof:lastmodified":1695881172,
     "wof:name":"Oman",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/756/81/85675681.geojson
+++ b/data/856/756/81/85675681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.78575,
-    "geom:area_square_m":31910142948.575115,
+    "geom:area_square_m":31910142783.216957,
     "geom:bbox":"56.527701,20.898462,58.390161,23.508344",
     "geom:latitude":22.11399,
     "geom:longitude":57.397023,
@@ -297,16 +297,18 @@
         "gn:id":411735,
         "gp:id":2346261,
         "hasc:id":"OM.DA",
+        "iso:code":"OM-DA",
         "iso:id":"OM-DA",
         "qs_pg:id":1135164,
         "unlc:id":"OM-DA",
         "wd:id":"Q792550"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"OM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"beaaa170c7f43fdbc13b081c2469150c",
+    "wof:geomhash":"552efdd524b5b823b722391ffd25ca86",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690850214,
+    "wof:lastmodified":1695884841,
     "wof:name":"Ad Dakhliyah",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/756/85/85675685.geojson
+++ b/data/856/756/85/85675685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.129381,
-    "geom:area_square_m":82802975019.388657,
+    "geom:area_square_m":82802971848.085999,
     "geom:bbox":"54.999137,17.929479,58.807083,21.49002",
     "geom:latitude":20.045015,
     "geom:longitude":56.635426,
@@ -287,15 +287,17 @@
         "gn:id":411737,
         "gp:id":2346257,
         "hasc:id":"OM.WU",
+        "iso:code":"OM-WU",
         "iso:id":"OM-WU",
         "qs_pg:id":1135161,
         "wd:id":"Q958518"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"OM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bef962106ea86e52597cd18b02bdb53f",
+    "wof:geomhash":"fc198a77cb569d52f1d0a17a6c331c26",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -310,7 +312,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690850215,
+    "wof:lastmodified":1695884841,
     "wof:name":"Al Wusta",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/756/91/85675691.geojson
+++ b/data/856/756/91/85675691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.06027,
-    "geom:area_square_m":12166965224.579624,
+    "geom:area_square_m":12166965224.578114,
     "geom:bbox":"58.589499,20.158722,59.837917,22.883213",
     "geom:latitude":21.86228,
     "geom:longitude":59.202252,
@@ -236,15 +236,17 @@
         "fips:code":"MU04",
         "gp:id":2346256,
         "hasc:id":"OM.SS",
+        "iso:code":"OM-SJ",
         "iso:id":"OM-SJ",
         "qs_pg:id":1135160,
         "wd:id":"Q4501894"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"OM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2b373f19060a6d6b05a10ac9d78cd77b",
+    "wof:geomhash":"a2aa5b405503bd3058b380c8ab8834dc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -259,7 +261,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690850214,
+    "wof:lastmodified":1695884842,
     "wof:name":"Ash Sharqiyah South",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/756/95/85675695.geojson
+++ b/data/856/756/95/85675695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.444822,
-    "geom:area_square_m":99123124359.894257,
+    "geom:area_square_m":99123123642.60672,
     "geom:bbox":"52.0,16.650084,56.356194,19.999712",
     "geom:latitude":18.333043,
     "geom:longitude":54.096327,
@@ -295,15 +295,17 @@
         "gn:id":411742,
         "gp:id":2346258,
         "hasc:id":"OM.JA",
+        "iso:code":"OM-ZU",
         "iso:id":"OM-ZU",
         "qs_pg:id":1135162,
         "wd:id":"Q1207752"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"OM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2bda85a398f71d4a5018583164edc664",
+    "wof:geomhash":"db4f59ad902cf3b108f682d57c6062f1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690850213,
+    "wof:lastmodified":1695884841,
     "wof:name":"Dhofar",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/756/99/85675699.geojson
+++ b/data/856/756/99/85675699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.153096,
-    "geom:area_square_m":35974060936.696388,
+    "geom:area_square_m":35974058742.000252,
     "geom:bbox":"55.21335,21.340868,57.142504,24.013653",
     "geom:latitude":22.673529,
     "geom:longitude":56.139002,
@@ -286,17 +286,19 @@
         "gn:id":411739,
         "gp:id":2346255,
         "hasc:id":"OM.DH",
+        "iso:code":"OM-ZA",
         "iso:id":"OM-ZA",
         "qs_pg:id":890085,
         "unlc:id":"OM-ZA",
         "wd:id":"Q1468596",
         "wk:page":"Ad Dhahirah Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"OM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd5934452712c67155f1b6dcf93ee5d4",
+    "wof:geomhash":"4037a7f8afd928cf3548d8483925451a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690850214,
+    "wof:lastmodified":1695884355,
     "wof:name":"Adh Dhahirah",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/757/03/85675703.geojson
+++ b/data/856/757/03/85675703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.698892,
-    "geom:area_square_m":7887778921.982136,
+    "geom:area_square_m":7887779704.049086,
     "geom:bbox":"56.17695,23.531133,57.536074,24.981369",
     "geom:latitude":24.112028,
     "geom:longitude":56.713367,
@@ -225,15 +225,17 @@
         "fips:code":"MU11",
         "gp:id":7038775,
         "hasc:id":"OM.BN",
+        "iso:code":"OM-BS",
         "iso:id":"OM-BS",
         "qs_pg:id":216507,
         "wd:id":"Q4703565"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"OM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3018d8a6d0fad601e9cbd77e09cdd5bf",
+    "wof:geomhash":"358be4bdf6e662968267daf0713c079a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -248,7 +250,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690850215,
+    "wof:lastmodified":1695884842,
     "wof:name":"Al Batnah North",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/757/09/85675709.geojson
+++ b/data/856/757/09/85675709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.151609,
-    "geom:area_square_m":1685625508.442989,
+    "geom:area_square_m":1685624871.784182,
     "geom:bbox":"56.087002,25.227219,56.542027,26.505472",
     "geom:latitude":25.951337,
     "geom:longitude":56.286453,
@@ -308,16 +308,18 @@
         "gn:id":411741,
         "gp:id":4693371,
         "hasc:id":"OM.MU",
+        "iso:code":"OM-MU",
         "iso:id":"OM-MU",
         "qs_pg:id":1155898,
         "unlc:id":"OM-MU",
         "wd:id":"Q372144"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"OM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"86e9615aac84f91e5324b95717713068",
+    "wof:geomhash":"6e3827f4e4119e5aee4aa9a491dda126",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -332,7 +334,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690850216,
+    "wof:lastmodified":1695884355,
     "wof:name":"Musandam",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/757/13/85675713.geojson
+++ b/data/856/757/13/85675713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.333049,
-    "geom:area_square_m":3781747201.911251,
+    "geom:area_square_m":3781748088.485007,
     "geom:bbox":"58.062051,22.840231,59.224609,23.86039",
     "geom:latitude":23.320539,
     "geom:longitude":58.626925,
@@ -336,16 +336,18 @@
         "gn:id":411740,
         "gp:id":2346260,
         "hasc:id":"OM.MA",
+        "iso:code":"OM-MA",
         "iso:id":"OM-MA",
         "qs_pg:id":1135163,
         "unlc:id":"OM-MA",
         "wd:id":"Q544762"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"OM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b5b41ae975f0202c8d435a9804382e6",
+    "wof:geomhash":"b01a00730eb6b16f065c136054a93a55",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -360,7 +362,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690850216,
+    "wof:lastmodified":1695884842,
     "wof:name":"Muscat",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/757/17/85675717.geojson
+++ b/data/856/757/17/85675717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.663373,
-    "geom:area_square_m":7486682234.783645,
+    "geom:area_square_m":7486681623.359944,
     "geom:bbox":"55.417738,23.337031,56.402688,25.005936",
     "geom:latitude":24.114599,
     "geom:longitude":55.915546,
@@ -292,17 +292,19 @@
         "gn:id":7110710,
         "gp:id":55927046,
         "hasc:id":"OM.BU",
+        "iso:code":"OM-BU",
         "iso:id":"OM-BU",
         "qs_pg:id":1086748,
         "unlc:id":"OM-BU",
         "wd:id":"Q852039",
         "wk:page":"Al Buraimi Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"OM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ffc6f719dc5d5c54d93141f88de83214",
+    "wof:geomhash":"1feb31aa038491faf1946eb224564a21",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -317,7 +319,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690850215,
+    "wof:lastmodified":1695884355,
     "wof:name":"Al Buraymi",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/757/21/85675721.geojson
+++ b/data/856/757/21/85675721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.85183,
-    "geom:area_square_m":21189576308.645988,
+    "geom:area_square_m":21189576988.944061,
     "geom:bbox":"57.662942,21.160056,59.230122,23.245368",
     "geom:latitude":22.269445,
     "geom:longitude":58.457503,
@@ -230,15 +230,17 @@
         "fips:code":"MU12",
         "gp:id":2346256,
         "hasc:id":"OM.SN",
+        "iso:code":"OM-SS",
         "iso:id":"OM-SS",
         "qs_pg:id":1135160,
         "wd:id":"Q4501876"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"OM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"beae37c2725bad5734575ee10f47d594",
+    "wof:geomhash":"ca511de8cd32b83382ea16737222c7ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -253,7 +255,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690850216,
+    "wof:lastmodified":1695884842,
     "wof:name":"Ash Sharqiyah North",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/856/757/27/85675727.geojson
+++ b/data/856/757/27/85675727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.469248,
-    "geom:area_square_m":5322268549.168267,
+    "geom:area_square_m":5322268049.967391,
     "geom:bbox":"57.010072,23.119191,58.093925,23.853045",
     "geom:latitude":23.470512,
     "geom:longitude":57.570525,
@@ -227,15 +227,17 @@
         "fips:code":"MU02",
         "gp:id":7038775,
         "hasc:id":"OM.BS",
+        "iso:code":"OM-BJ",
         "iso:id":"OM-BJ",
         "qs_pg:id":216507,
         "wd:id":"Q4703565"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"OM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"215823549819cbcfe4ae889b5aa2c28d",
+    "wof:geomhash":"64deccd10bcd97fb64cbacc1172f3362",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -250,7 +252,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690850215,
+    "wof:lastmodified":1695884842,
     "wof:name":"Al Batnah South",
     "wof:parent_id":85632207,
     "wof:placetype":"region",

--- a/data/890/441/841/890441841.geojson
+++ b/data/890/441/841/890441841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060774,
-    "geom:area_square_m":688367554.79927,
+    "geom:area_square_m":688367554.799131,
     "geom:bbox":"57.646009,23.537456,58.093925,23.853045",
     "geom:latitude":23.648953,
     "geom:longitude":57.865395,
@@ -216,12 +216,13 @@
         "qs_pg:id":1295825,
         "wd:id":"Q808238"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1469052339,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6a0c70507be9953c7991cc4ffca3bc02",
+    "wof:geomhash":"24906d2448ffde8420ee0459cad5195a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":890441841,
-    "wof:lastmodified":1690850229,
+    "wof:lastmodified":1695886290,
     "wof:name":"Barka",
     "wof:parent_id":85675727,
     "wof:placetype":"county",

--- a/data/890/452/027/890452027.geojson
+++ b/data/890/452/027/890452027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04742,
-    "geom:area_square_m":536954497.177691,
+    "geom:area_square_m":536954442.062475,
     "geom:bbox":"57.424081,23.536997,57.719726,23.818561",
     "geom:latitude":23.687737,
     "geom:longitude":57.573572,
@@ -91,12 +91,13 @@
         "hasc:id":"OM.BS.MU",
         "qs_pg:id":231737
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"OM",
     "wof:created":1469052801,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"86b2e6cbd1293dacbc4f489a900ec0b8",
+    "wof:geomhash":"9bee6a6e2f003e8ad6626b13127f2b05",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":890452027,
-    "wof:lastmodified":1627522485,
+    "wof:lastmodified":1695886120,
     "wof:name":"Al Musanaah",
     "wof:parent_id":85675727,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.